### PR TITLE
api func fixes

### DIFF
--- a/src/Impl/Actors/APIs.cpp
+++ b/src/Impl/Actors/APIs.cpp
@@ -8,7 +8,7 @@
 
 #include "../ComponentManager.hpp"
 
-OMP_CAPI(Actor_Create, objectPtr(int model, float x, float y, float z, float rot, int* id))
+OMP_CAPI(Actor_Create, objectPtr(int model, float x, float y, float z, float rot))
 {
 	IActorsComponent* component = ComponentManager::Get()->actors;
 	if (component)
@@ -16,7 +16,6 @@ OMP_CAPI(Actor_Create, objectPtr(int model, float x, float y, float z, float rot
 		IActor* actor = component->create(model, { x, y, z }, rot);
 		if (actor)
 		{
-			*id = actor->getID();
 			return actor;
 		}
 	}

--- a/src/Impl/Actors/APIs.cpp
+++ b/src/Impl/Actors/APIs.cpp
@@ -22,11 +22,10 @@ OMP_CAPI(Actor_Create, objectPtr(int model, float x, float y, float z, float rot
 	return nullptr;
 }
 
-OMP_CAPI(Actor_Destroy, bool(objectPtr actor))
+OMP_CAPI(Actor_Destroy, void(objectPtr actor))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actors->release(actor_->getID());
-	return true;
 }
 
 OMP_CAPI(Actor_FromID, objectPtr(int actorid))
@@ -52,11 +51,10 @@ OMP_CAPI(Actor_IsStreamedInFor, bool(objectPtr actor, objectPtr player))
 	return actor_->isStreamedInForPlayer(*player_);
 }
 
-OMP_CAPI(Actor_SetVirtualWorld, bool(objectPtr actor, int vw))
+OMP_CAPI(Actor_SetVirtualWorld, void(objectPtr actor, int vw))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actor_->setVirtualWorld(vw);
-	return true;
 }
 
 OMP_CAPI(Actor_GetVirtualWorld, int(objectPtr actor))
@@ -65,44 +63,39 @@ OMP_CAPI(Actor_GetVirtualWorld, int(objectPtr actor))
 	return actor_->getVirtualWorld();
 }
 
-OMP_CAPI(Actor_ApplyAnimation, bool(objectPtr actor, StringCharPtr name, StringCharPtr library, float delta, bool loop, bool lockX, bool lockY, bool freeze, int time))
+OMP_CAPI(Actor_ApplyAnimation, void(objectPtr actor, StringCharPtr name, StringCharPtr library, float delta, bool loop, bool lockX, bool lockY, bool freeze, int time))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	const AnimationData animationData(delta, loop, lockX, lockY, freeze, uint32_t(time), library, name);
 	actor_->applyAnimation(animationData);
-	return true;
 }
 
-OMP_CAPI(Actor_ClearAnimations, bool(objectPtr actor))
+OMP_CAPI(Actor_ClearAnimations, void(objectPtr actor))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actor_->clearAnimations();
-	return true;
 }
 
-OMP_CAPI(Actor_SetPos, bool(objectPtr actor, float x, float y, float z))
+OMP_CAPI(Actor_SetPos, void(objectPtr actor, float x, float y, float z))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actor_->setPosition({ x, y, z });
-	return true;
 }
 
-OMP_CAPI(Actor_GetPos, bool(objectPtr actor, float* x, float* y, float* z))
+OMP_CAPI(Actor_GetPos, void(objectPtr actor, float* x, float* y, float* z))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	const Vector3& pos = actor_->getPosition();
 
 	*x = pos.x;
 	*y = pos.y;
 	*z = pos.z;
-	return true;
 }
 
-OMP_CAPI(Actor_SetFacingAngle, bool(objectPtr actor, float angle))
+OMP_CAPI(Actor_SetFacingAngle, void(objectPtr actor, float angle))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actor_->setRotation(Vector3(0.0f, 0.0f, angle));
-	return true;
 }
 
 OMP_CAPI(Actor_GetFacingAngle, float(objectPtr actor))
@@ -111,11 +104,10 @@ OMP_CAPI(Actor_GetFacingAngle, float(objectPtr actor))
 	return actor_->getRotation().ToEuler().z;
 }
 
-OMP_CAPI(Actor_SetHealth, bool(objectPtr actor, float hp))
+OMP_CAPI(Actor_SetHealth, void(objectPtr actor, float hp))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actor_->setHealth(hp);
-	return true;
 }
 
 OMP_CAPI(Actor_GetHealth, float(objectPtr actor))
@@ -124,11 +116,10 @@ OMP_CAPI(Actor_GetHealth, float(objectPtr actor))
 	return actor_->getHealth();
 }
 
-OMP_CAPI(Actor_SetInvulnerable, bool(objectPtr actor, bool toggle))
+OMP_CAPI(Actor_SetInvulnerable, void(objectPtr actor, bool toggle))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actor_->setInvulnerable(toggle);
-	return true;
 }
 
 OMP_CAPI(Actor_IsInvulnerable, bool(objectPtr actor))
@@ -145,11 +136,10 @@ OMP_CAPI(Actor_IsValid, bool(objectPtr actor))
 	return true;
 }
 
-OMP_CAPI(Actor_SetSkin, bool(objectPtr actor, int skin))
+OMP_CAPI(Actor_SetSkin, void(objectPtr actor, int skin))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	actor_->setSkin(skin);
-	return true;
 }
 
 OMP_CAPI(Actor_GetSkin, int(objectPtr actor))
@@ -158,9 +148,9 @@ OMP_CAPI(Actor_GetSkin, int(objectPtr actor))
 	return actor_->getSkin();
 }
 
-OMP_CAPI(Actor_GetAnimation, bool(objectPtr actor, OutputStringViewPtr library, OutputStringViewPtr name, float* delta, bool* loop, bool* lockX, bool* lockY, bool* freeze, int* time))
+OMP_CAPI(Actor_GetAnimation, void(objectPtr actor, OutputStringViewPtr library, OutputStringViewPtr name, float* delta, bool* loop, bool* lockX, bool* lockY, bool* freeze, int* time))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	const AnimationData& anim = actor_->getAnimation();
 
 	SET_CAPI_STRING_VIEW(library, anim.lib);
@@ -171,12 +161,11 @@ OMP_CAPI(Actor_GetAnimation, bool(objectPtr actor, OutputStringViewPtr library, 
 	*lockY = anim.lockY;
 	*freeze = anim.freeze;
 	*time = int(anim.time);
-	return true;
 }
 
-OMP_CAPI(Actor_GetSpawnInfo, bool(objectPtr actor, float* x, float* y, float* z, float* angle, int* skin))
+OMP_CAPI(Actor_GetSpawnInfo, void(objectPtr actor, float* x, float* y, float* z, float* angle, int* skin))
 {
-	POOL_ENTITY_RET(actors, IActor, actor, actor_, false);
+	POOL_ENTITY(actors, IActor, actor, actor_);
 	const ActorSpawnData& spawnData = actor_->getSpawnData();
 
 	*x = spawnData.position.x;
@@ -184,5 +173,4 @@ OMP_CAPI(Actor_GetSpawnInfo, bool(objectPtr actor, float* x, float* y, float* z,
 	*z = spawnData.position.z;
 	*angle = spawnData.facingAngle;
 	*skin = spawnData.skin;
-	return true;
 }

--- a/src/Impl/Checkpoints/APIs.cpp
+++ b/src/Impl/Checkpoints/APIs.cpp
@@ -11,7 +11,7 @@
 OMP_CAPI(Checkpoint_SetPosition, void(objectPtr checkpoint, float x, float y, float z))
 {
 	ENTITY_CAST(ICheckpointData, checkpoint, checkpoint_);
-	checkpoint_.setPosition({ x, y, z });
+	checkpoint_->setPosition({ x, y, z });
 }
 
 OMP_CAPI(Checkpoint_SetRadius, void(objectPtr checkpoint, float radius))
@@ -54,13 +54,13 @@ OMP_CAPI(RaceCheckpoint_SetType, void(objectPtr cp, int type))
 OMP_CAPI(RaceCheckpoint_SetPosition, void(objectPtr cp, float x, float y, float z))
 {
 	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
-	cp_.setPosition({ x, y, z });
+	cp_->setPosition({ x, y, z });
 }
 
 OMP_CAPI(RaceCheckpoint_SetNextPosition, void(objectPtr cp, float x, float y, float z))
 {
 	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
-	cp_.setNextPosition({ x, y, z });
+	cp_->setNextPosition({ x, y, z });
 }
 
 OMP_CAPI(RaceCheckpoint_SetRadius, void(objectPtr cp, float radius))

--- a/src/Impl/Checkpoints/APIs.cpp
+++ b/src/Impl/Checkpoints/APIs.cpp
@@ -8,154 +8,87 @@
 
 #include "../ComponentManager.hpp"
 
-OMP_CAPI(Checkpoint_Set, bool(objectPtr player, float x, float y, float z, float radius))
+OMP_CAPI(Checkpoint_SetPosition, void(objectPtr checkpoint, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerCheckpointData)
-	{
-		ICheckpointData& cp = playerCheckpointData->getCheckpoint();
-		cp.setPosition({ x, y, z });
-		cp.setRadius(radius);
-		cp.enable();
-		return true;
-	}
-	return false;
+	ENTITY_CAST(ICheckpointData, checkpoint, checkpoint_);
+	checkpoint_.setPosition({ x, y, z });
 }
 
-OMP_CAPI(Checkpoint_Disable, bool(objectPtr player))
+OMP_CAPI(Checkpoint_SetRadius, void(objectPtr checkpoint, float radius))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerCheckpointData)
-	{
-		ICheckpointData& cp = playerCheckpointData->getCheckpoint();
-		cp.disable();
-		return true;
-	}
-	return false;
+	ENTITY_CAST(ICheckpointData, checkpoint, checkpoint_);
+	checkpoint_->setRadius(radius);
 }
 
-OMP_CAPI(Checkpoint_IsPlayerIn, bool(objectPtr player))
+OMP_CAPI(Checkpoint_Enable, void(objectPtr checkpoint))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerCheckpointData)
-	{
-		ICheckpointData& cp = playerCheckpointData->getCheckpoint();
-		if (cp.isEnabled())
-		{
-			bool isIn = cp.isPlayerInside();
-			return isIn;
-		}
-	}
-	return false;
+	ENTITY_CAST(ICheckpointData, checkpoint, checkpoint_);
+	checkpoint_->enable();
 }
 
-OMP_CAPI(Checkpoint_IsActive, bool(objectPtr player))
+OMP_CAPI(Checkpoint_Disable, void(objectPtr checkpoint))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerData)
-	{
-		bool active = playerData->getCheckpoint().isEnabled();
-		return active;
-	}
-	return false;
+	ENTITY_CAST(ICheckpointData, checkpoint, checkpoint_);
+	checkpoint_->disable();
 }
 
-OMP_CAPI(Checkpoint_Get, bool(objectPtr player, float* x, float* y, float* z, float* radius))
+OMP_CAPI(Checkpoint_IsEnabled, bool(objectPtr checkpoint))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerData)
-	{
-		const ICheckpointData& data = playerData->getCheckpoint();
-		*x = data.getPosition().x;
-		*y = data.getPosition().y;
-		*z = data.getPosition().z;
-		*radius = data.getRadius();
-		return true;
-	}
-	return false;
+	ENTITY_CAST_RET(ICheckpointData, checkpoint, checkpoint_, false);
+	return checkpoint_->isEnabled();
 }
 
-OMP_CAPI(RaceCheckpoint_Set, bool(objectPtr player, int type, float x, float y, float z, float nextX, float nextY, float nextZ, float radius))
+OMP_CAPI(Checkpoint_IsPlayerInside, bool(objectPtr checkpoint))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerCheckpointData)
-	{
-		IRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
-		if (type >= 0 && type <= 8)
-		{
-			cp.setType(RaceCheckpointType(type));
-			cp.setPosition({ x, y, z });
-			cp.setNextPosition({ nextX, nextY, nextZ });
-			cp.setRadius(radius);
-			cp.enable();
-			return true;
-		}
-	}
-	return false;
+	ENTITY_CAST_RET(ICheckpointData, checkpoint, checkpoint_, false);
+	return checkpoint_->isPlayerInside();
 }
 
-OMP_CAPI(RaceCheckpoint_Disable, bool(objectPtr player))
+
+OMP_CAPI(RaceCheckpoint_SetType, void(objectPtr cp, int type))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerCheckpointData)
-	{
-		IRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
-		cp.disable();
-		return true;
-	}
-	return false;
+	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
+	cp_->setType(RaceCheckpointType(type));
 }
 
-OMP_CAPI(RaceCheckpoint_IsPlayerIn, bool(objectPtr player))
+OMP_CAPI(RaceCheckpoint_SetPosition, void(objectPtr cp, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerCheckpointData)
-	{
-		IRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
-		if (cp.getType() != RaceCheckpointType::RACE_NONE && cp.isEnabled())
-		{
-			bool isIn = cp.isPlayerInside();
-			return isIn;
-		}
-	}
-	return false;
+	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
+	cp_.setPosition({ x, y, z });
 }
 
-OMP_CAPI(RaceCheckpoint_IsActive, bool(objectPtr player))
+OMP_CAPI(RaceCheckpoint_SetNextPosition, void(objectPtr cp, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerData)
-	{
-		bool active = playerData->getCheckpoint().isEnabled();
-		return active;
-	}
-	return false;
+	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
+	cp_.setNextPosition({ x, y, z });
 }
 
-OMP_CAPI(RaceCheckpoint_Get, bool(objectPtr player, float* x, float* y, float* z, float* nextX, float* nextY, float* nextZ, float* radius))
+OMP_CAPI(RaceCheckpoint_SetRadius, void(objectPtr cp, float radius))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player_);
-	if (playerData)
-	{
-		const IRaceCheckpointData& data = playerData->getRaceCheckpoint();
-		*x = data.getPosition().x;
-		*y = data.getPosition().y;
-		*z = data.getPosition().z;
-		*nextX = data.getNextPosition().x;
-		*nextY = data.getNextPosition().y;
-		*nextZ = data.getNextPosition().z;
-		*radius = data.getRadius();
-		return true;
-	}
-	return false;
+	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
+	cp_->setRadius(radius);
+}
+
+OMP_CAPI(RaceCheckpoint_Enable, void(objectPtr cp))
+{
+	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
+	cp_->enable();
+}
+
+OMP_CAPI(RaceCheckpoint_Disable, void(objectPtr cp))
+{
+	ENTITY_CAST(IRaceCheckpointData, cp, cp_);
+	cp_->disable();
+}
+
+OMP_CAPI(RaceCheckpoint_IsEnabled, bool(objectPtr cp))
+{
+	ENTITY_CAST_RET(IRaceCheckpointData, cp, cp_, false);
+	return cp_->isEnabled();
+}
+
+OMP_CAPI(RaceCheckpoint_IsPlayerInside, bool(objectPtr cp))
+{
+	ENTITY_CAST_RET(IRaceCheckpointData, cp, cp_, false);
+	return cp_->isPlayerInside();
 }

--- a/src/Impl/ComponentManager.hpp
+++ b/src/Impl/ComponentManager.hpp
@@ -266,6 +266,11 @@ inline PlayerDataType* GetPlayerData(IPlayer* player)
 	if (entity_output == nullptr)                                    \
 	return failret
 
+#define PLAYER_DATA(player, entity_type, entity_output) \
+	auto entity_output = GetPlayerData<entity_type>(player);         \
+	if (entity_output == nullptr)                                    \
+	return
+
 #define COPY_STRING_TO_CAPI_STRING_VIEW(output, src, len_) \
 	if (output)                                            \
 	{                                                      \

--- a/src/Impl/ComponentManager.hpp
+++ b/src/Impl/ComponentManager.hpp
@@ -253,6 +253,14 @@ inline PlayerDataType* GetPlayerData(IPlayer* player)
 	if (entity_output == nullptr)                                                              \
 		return failret;
 
+#define PLAYER_POOL_ENTITY(player, pool_type, entity_type, entity, entity_output) \
+	auto playerData = GetPlayerData<pool_type>(player);                                        \
+	if (playerData == nullptr)                                                                 \
+		return;                                                                        \
+	entity_type* entity_output = reinterpret_cast<entity_type*>(entity);                       \
+	if (entity_output == nullptr)                                                              \
+		return;
+
 #define PLAYER_DATA_RET(player, entity_type, entity_output, failret) \
 	auto entity_output = GetPlayerData<entity_type>(player);         \
 	if (entity_output == nullptr)                                    \

--- a/src/Impl/CustomModels/APIs.cpp
+++ b/src/Impl/CustomModels/APIs.cpp
@@ -44,34 +44,6 @@ OMP_CAPI(CustomModel_AddSimpleModelTimed, bool(int virtualWorld, int baseid, int
 	return ret;
 }
 
-OMP_CAPI(Player_GetCustomSkin, int(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	IPlayerCustomModelsData* data = queryExtension<IPlayerCustomModelsData>(player_);
-	if (!data)
-	{
-		return 0;
-	}
-	auto skin = data->getCustomSkin();
-	return skin;
-}
-
-OMP_CAPI(CustomModel_RedirectDownload, bool(objectPtr player, StringCharPtr url))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerCustomModelsData* data = queryExtension<IPlayerCustomModelsData>(player_);
-	if (!data)
-	{
-		return false;
-	}
-	if (!data->sendDownloadUrl(url))
-	{
-		ComponentManager::Get()->core->logLn(LogLevel::Warning, "This native can be used only within OnPlayerRequestDownload callback.");
-		return false;
-	}
-	return true;
-}
-
 OMP_CAPI(CustomModel_FindModelFileNameFromCRC, int(int crc, OutputStringViewPtr output))
 {
 	auto models = ComponentManager::Get()->models;

--- a/src/Impl/Menus/APIs.cpp
+++ b/src/Impl/Menus/APIs.cpp
@@ -90,21 +90,6 @@ OMP_CAPI(Menu_DisableRow, bool(objectPtr menu, uint8_t row))
 	return true;
 }
 
-OMP_CAPI(Player_GetMenu, objectPtr(objectPtr player))
-{
-	IMenusComponent* component = ComponentManager::Get()->menus;
-	if (component)
-	{
-		POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
-		IPlayerMenuData* menuData = queryExtension<IPlayerMenuData>(player_);
-		if (menuData)
-		{
-			return component->get(menuData->getMenuID());
-		}
-	}
-	return nullptr;
-}
-
 OMP_CAPI(Menu_IsValid, bool(objectPtr menu))
 {
 	POOL_ENTITY_RET(menus, IMenu, menu, menu_, false);

--- a/src/Impl/Objects/APIs.cpp
+++ b/src/Impl/Objects/APIs.cpp
@@ -176,46 +176,6 @@ OMP_CAPI(Object_IsMoving, bool(objectPtr object))
 	return moving;
 }
 
-OMP_CAPI(Object_BeginEditing, bool(objectPtr player, objectPtr object))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player_);
-	if (!data)
-	{
-		return false;
-	}
-
-	POOL_ENTITY_RET(objects, IObject, object, object_, false);
-	data->beginEditing(*object_);
-	return true;
-}
-
-OMP_CAPI(Object_BeginSelecting, bool(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player_);
-	if (!data)
-	{
-		return false;
-	}
-
-	data->beginSelecting();
-	return true;
-}
-
-OMP_CAPI(Object_EndEditing, bool(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player_);
-	if (!data)
-	{
-		return false;
-	}
-
-	data->endEditing();
-	return true;
-}
-
 OMP_CAPI(Object_SetMaterial, bool(objectPtr object, int materialIndex, int modelId, StringCharPtr textureLibrary, StringCharPtr textureName, uint32_t materialColor))
 {
 	POOL_ENTITY_RET(objects, IObject, object, object_, false);
@@ -613,20 +573,6 @@ OMP_CAPI(PlayerObject_IsMoving, bool(objectPtr player, objectPtr object))
 
 	bool moving = object_->isMoving();
 	return moving;
-}
-
-OMP_CAPI(PlayerObject_BeginEditing, bool(objectPtr player, objectPtr object))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player_);
-	if (!data)
-	{
-		return false;
-	}
-
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerObjectData, IPlayerObject, object, object_, false);
-	data->beginEditing(*object_);
-	return true;
 }
 
 OMP_CAPI(PlayerObject_SetMaterial, bool(objectPtr player, objectPtr object, int materialIndex, int modelId, StringCharPtr textureLibrary, StringCharPtr textureName, uint32_t materialColor))

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -332,10 +332,10 @@ OMP_CAPI(Player_GetPing, int(objectPtr player))
 	return ping;
 }
 
-OMP_CAPI(Player_GetArmedWeapon, int(objectPtr player))
+OMP_CAPI(Player_GetArmedWeapon, uint32_t(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	int weapon = player_->getArmedWeapon();
+	uint32_t weapon = player_->getArmedWeapon();
 	return weapon;
 }
 

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -493,7 +493,7 @@ OMP_CAPI(Player_IsStreamedIn, bool(objectPtr player, objectPtr other))
 	return streamed;
 }
 
-OMP_CAPI(Player_PlayGameSound, bool(objectPtr player, int sound, float x, float y, float z))
+OMP_CAPI(Player_PlayGameSound, bool(objectPtr player, uint32_t sound, float x, float y, float z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->playSound(sound, { x, y, z });

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1310,7 +1310,7 @@ OMP_CAPI(Player_IsSpawned, bool(objectPtr player))
 	return spawned;
 }
 
-OMP_CAPI(Player_IsControllable, bool(objectPtr player))
+OMP_CAPI(Player_GetControllable, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	bool controllable = bool(player_->getControllable());

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -658,7 +658,7 @@ OMP_CAPI(Player_SetAmmo, bool(objectPtr player, uint8_t id, uint32_t ammo))
 	return true;
 }
 
-OMP_CAPI(Player_SetArmedWeapon, bool(objectPtr player, uint8_t weapon))
+OMP_CAPI(Player_SetArmedWeapon, bool(objectPtr player, uint32_t weapon))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setArmedWeapon(weapon);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -965,8 +965,7 @@ OMP_CAPI(Player_PlayCrimeReport, bool(objectPtr player, objectPtr suspect, int c
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, suspect, suspect_, false);
-	bool ret = bool(player_->playerCrimeReport(*suspect_, crime));
-	return ret;
+	return player_->playerCrimeReport(*suspect_, crime);
 }
 
 OMP_CAPI(Player_RemoveAttachedObject, bool(objectPtr player, int index))

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -37,7 +37,7 @@ OMP_CAPI(All_SendClientMessage, bool(uint32_t color, StringCharPtr text))
 	return true;
 }
 
-OMP_CAPI(Player_SetCameraPos, bool(objectPtr player, float x, float y, float z))
+OMP_CAPI(Player_SetCameraPosition, bool(objectPtr player, float x, float y, float z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setCameraPosition({ x, y, z });

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1122,13 +1122,8 @@ OMP_CAPI(Player_Kick, bool(objectPtr player))
 
 OMP_CAPI(Player_SendGameText, bool(objectPtr player, StringCharPtr text, int time, int style))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	if (strlen(text) > 1)
-	{
-		return false;
-	}
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->sendGameText(text, Milliseconds(time), style);
-	return true;
 }
 
 OMP_CAPI(Player_HideGameText, bool(objectPtr player, int style))

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -368,7 +368,7 @@ OMP_CAPI(Player_GetTime, bool(objectPtr player, int* hour, int* minute))
 	return true;
 }
 
-OMP_CAPI(Player_ToggleClock, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_UseClock, bool(objectPtr player, bool enable))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->useClock(enable);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1025,7 +1025,7 @@ OMP_CAPI(Player_SetOtherColor, bool(objectPtr player, objectPtr other, uint32_t 
 	return true;
 }
 
-OMP_CAPI(Player_GetMarkerForPlayer, bool(objectPtr player, objectPtr other))
+OMP_CAPI(Player_GetOtherColor, bool(objectPtr player, objectPtr other))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, other, other_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -271,7 +271,7 @@ OMP_CAPI(Player_GetDrunkLevel, int(objectPtr player))
 	return level;
 }
 
-OMP_CAPI(Player_GiveWeapon, bool(objectPtr player, int weapon, int ammo))
+OMP_CAPI(Player_GiveWeapon, bool(objectPtr player, uint8_t weapon, uint32_t ammo))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	WeaponSlotData data;

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -51,7 +51,7 @@ OMP_CAPI(Player_SetDrunkLevel, bool(objectPtr player, int level))
 	return true;
 }
 
-OMP_CAPI(Player_SetInterior, bool(objectPtr player, int interior))
+OMP_CAPI(Player_SetInterior, bool(objectPtr player, unsigned interior))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setInterior(interior);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1120,7 +1120,7 @@ OMP_CAPI(Player_Kick, bool(objectPtr player))
 	return true;
 }
 
-OMP_CAPI(Player_ShowGameText, bool(objectPtr player, StringCharPtr text, int time, int style))
+OMP_CAPI(Player_SendGameText, bool(objectPtr player, StringCharPtr text, int time, int style))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	if (strlen(text) > 1)

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1207,6 +1207,13 @@ OMP_CAPI(Player_SendMessageToPlayer, bool(objectPtr player, objectPtr sender, St
 	return true;
 }
 
+OMP_CAPI(Player_GetClientVersion, int(objectPtr player))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	auto version = player_->getClientVersion();
+	return int(version);
+}
+
 OMP_CAPI(Player_GetClientVersionName, void(objectPtr player, OutputStringViewPtr version))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1207,7 +1207,7 @@ OMP_CAPI(Player_SendMessageToPlayer, bool(objectPtr player, objectPtr sender, St
 	return true;
 }
 
-OMP_CAPI(Player_GetVersion, int(objectPtr player, OutputStringViewPtr version))
+OMP_CAPI(Player_GetClientVersionName, int(objectPtr player, OutputStringViewPtr version))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	auto versionStr = player_->getClientVersionName();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -648,7 +648,7 @@ OMP_CAPI(Player_SetChatBubble, bool(objectPtr player, StringCharPtr text, uint32
 	return true;
 }
 
-OMP_CAPI(Player_SetPosFindZ, bool(objectPtr player, float x, float y, float z))
+OMP_CAPI(Player_SetPositionFindZ, bool(objectPtr player, float x, float y, float z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setPositionFindZ({ x, y, z });

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -691,7 +691,7 @@ OMP_CAPI(Player_SetSkillLevel, bool(objectPtr player, uint8_t weapon, int level)
 	return true;
 }
 
-OMP_CAPI(Player_SetAction, bool(objectPtr player, uint32_t action))
+OMP_CAPI(Player_SetAction, bool(objectPtr player, int action))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setAction(PlayerSpecialAction(action));

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -30,10 +30,9 @@ OMP_CAPI(Player_SendClientMessage, void(objectPtr player, uint32_t color, String
 	player_->sendClientMessage(Colour::FromRGBA(color), text);
 }
 
-OMP_CAPI(All_SendClientMessage, bool(uint32_t color, StringCharPtr text))
+OMP_CAPI(All_SendClientMessage, void(uint32_t color, StringCharPtr text))
 {
 	ComponentManager::Get()->players->sendClientMessageToAll(Colour::FromRGBA(color), text);
-	return true;
 }
 
 OMP_CAPI(Player_SetCameraPosition, void(objectPtr player, float x, float y, float z))
@@ -125,10 +124,9 @@ OMP_CAPI(Player_CreateExplosion, void(objectPtr player, float x, float y, float 
 	player_->createExplosion({ x, y, z }, type, radius);
 }
 
-OMP_CAPI(All_CreateExplosion, bool(float x, float y, float z, int type, float radius))
+OMP_CAPI(All_CreateExplosion, void(float x, float y, float z, int type, float radius))
 {
 	ComponentManager::Get()->players->createExplosionForAll({ x, y, z }, type, radius);
-	return true;
 }
 
 OMP_CAPI(Player_PlayAudio, void(objectPtr player, StringCharPtr url, bool usePos, float x, float y, float z, float distance))
@@ -143,19 +141,18 @@ OMP_CAPI(Player_StopAudio, void(objectPtr player))
 	player_->stopAudio();
 }
 
-OMP_CAPI(All_SendDeathMessage, bool(objectPtr killer, objectPtr killee, int weapon))
+OMP_CAPI(All_SendDeathMessage, void(objectPtr killer, objectPtr killee, int weapon))
 {
 	if (killee)
 	{
-		POOL_ENTITY_RET(players, IPlayer, killer, killer_, false);
-		ENTITY_CAST_RET(IPlayer, killee, killee_, false);
+		POOL_ENTITY(players, IPlayer, killer, killer_);
+		ENTITY_CAST(IPlayer, killee, killee_,);
 		ComponentManager::Get()->players->sendDeathMessageToAll(killer_, *killee_, weapon);
 	}
 	else
 	{
 		ComponentManager::Get()->players->sendEmptyDeathMessageToAll();
 	}
-	return true;
 }
 
 OMP_CAPI(Player_UseWidescreen, void(objectPtr player, bool enable))
@@ -401,9 +398,9 @@ OMP_CAPI(Player_GetVelocity, void(objectPtr player, float* x, float* y, float* z
 	*z = velocity.z;
 }
 
-OMP_CAPI(Player_GetAimData, bool(objectPtr player, float* frontVectorX, float* frontVectorY, float* frontVectorZ, float* posX, float* posY, float* posZ, float* aimZ, float* camZoom, float* aspectRatio, int8_t* weaponState, uint8_t* camMode))
+OMP_CAPI(Player_GetAimData, void(objectPtr player, float* frontVectorX, float* frontVectorY, float* frontVectorZ, float* posX, float* posY, float* posZ, float* aimZ, float* camZoom, float* aspectRatio, int8_t* weaponState, uint8_t* camMode))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto data = player_->getAimData();
 	*frontVectorX = data.camFrontVector.x;
 	*frontVectorY = data.camFrontVector.y;
@@ -416,7 +413,6 @@ OMP_CAPI(Player_GetAimData, bool(objectPtr player, float* frontVectorX, float* f
 	*aspectRatio = data.aspectRatio;
 	*weaponState = data.weaponState;
 	*camMode = data.camMode;
-	return true;
 }
 
 OMP_CAPI(Player_GetDistanceFromPoint, float(objectPtr player, float x, float y, float z))
@@ -440,14 +436,13 @@ OMP_CAPI(Player_SetPosition, void(objectPtr player, float x, float y, float z))
 	player_->setPosition({ x, y, z });
 }
 
-OMP_CAPI(Player_GetPos, bool(objectPtr player, float* x, float* y, float* z))
+OMP_CAPI(Player_GetPosition, void(objectPtr player, float* x, float* y, float* z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto pos = player_->getPosition();
 	*x = pos.x;
 	*y = pos.y;
 	*z = pos.z;
-	return true;
 }
 
 OMP_CAPI(Player_GetVirtualWorld, int(objectPtr player))
@@ -491,12 +486,11 @@ OMP_CAPI(Player_SpectatePlayer, void(objectPtr player, objectPtr target, int mod
 	player_->spectatePlayer(*target_, PlayerSpectateMode(mode));
 }
 
-OMP_CAPI(Player_SpectateVehicle, bool(objectPtr player, objectPtr target, int mode))
+OMP_CAPI(Player_SpectateVehicle, void(objectPtr player, objectPtr target, int mode))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	POOL_ENTITY_RET(vehicles, IVehicle, target, target_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	POOL_ENTITY(vehicles, IVehicle, target, target_);
 	player_->spectateVehicle(*target_, PlayerSpectateMode(mode));
-	return true;
 }
 
 OMP_CAPI(Player_SetVirtualWorld, void(objectPtr player, int vw))
@@ -528,22 +522,26 @@ OMP_CAPI(Player_ClearTasks, void(objectPtr player, int syncType))
 	player_->clearTasks(PlayerAnimationSyncType(syncType));
 }
 
-OMP_CAPI(Player_GetLastShotVectors, bool(objectPtr player, float* origin_x, float* origin_y, float* origin_z, float* hit_x, float* hit_y, float* hit_z))
+OMP_CAPI(Player_GetBulletData, void(objectPtr player, float* originX, float* originY, float* originZ, float* hitX, float* hitY, float* hitZ, float* offsetX, float* offsetY, float* offsetZ, uint8_t* weapon, int* hitType, uint16_t* hitID))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	PlayerBulletData data = player_->getBulletData();
-	auto origin = data.origin;
-	auto hitPos = data.hitPos;
 
-	*origin_x = origin.x;
-	*origin_y = origin.y;
-	*origin_z = origin.z;
+	*originX = data.origin.x;
+	*originY = data.origin.y;
+	*originZ = data.origin.z;
 
-	*hit_x = hitPos.x;
-	*hit_y = hitPos.y;
-	*hit_z = hitPos.z;
+	*hitX = data.hitPos.x;
+	*hitY = data.hitPos.y;
+	*hitZ = data.hitPos.z;
 
-	return true;
+	*offsetX = data.offset.x;
+	*offsetY = data.offset.y;
+	*offsetZ = data.offset.z;
+
+	*weapon = data.weapon;
+	*hitType = data.hitType;
+	*hitID = data.hitID;
 }
 
 OMP_CAPI(Player_GetCameraTargetPlayer, objectPtr(objectPtr player))
@@ -570,12 +568,11 @@ OMP_CAPI(Player_GetCameraTargetVehicle, objectPtr(objectPtr player))
 	return player_->getCameraTargetVehicle();
 }
 
-OMP_CAPI(Player_PutInVehicle, bool(objectPtr player, objectPtr vehicle, int seat))
+OMP_CAPI(Player_PutInVehicle, void(objectPtr player, objectPtr vehicle, int seat))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	POOL_ENTITY_RET(vehicles, IVehicle, vehicle, vehicle_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	POOL_ENTITY(vehicles, IVehicle, vehicle, vehicle_);
 	vehicle_->putPlayer(*player_, seat);
-	return true;
 }
 
 OMP_CAPI(Player_RemoveDefaultObjects, void(objectPtr player, unsigned model, float x, float y, float z, float radius))
@@ -614,14 +611,13 @@ OMP_CAPI(Player_ResetWeapons, void(objectPtr player))
 	player_->resetWeapons();
 }
 
-OMP_CAPI(Player_SetWeaponAmmo, bool(objectPtr player, uint8_t id, uint32_t ammo))
+OMP_CAPI(Player_SetWeaponAmmo, void(objectPtr player, uint8_t id, uint32_t ammo))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	WeaponSlotData data;
 	data.id = id;
 	data.ammo = ammo;
 	player_->setWeaponAmmo(data);
-	return true;
 }
 
 OMP_CAPI(Player_SetArmedWeapon, void(objectPtr player, uint32_t weapon))
@@ -680,12 +676,11 @@ OMP_CAPI(Player_ApplyAnimation, void(objectPtr player, float delta, bool loop, b
 	player_->applyAnimation(animationData, PlayerAnimationSyncType(sync));
 }
 
-OMP_CAPI(Player_GetAnimationName, bool(int index, OutputStringViewPtr lib, OutputStringViewPtr name))
+OMP_CAPI(Player_GetAnimationName, void(int index, OutputStringViewPtr lib, OutputStringViewPtr name))
 {
 	Pair<StringView, StringView> anim = splitAnimationNames(index);
 	SET_CAPI_STRING_VIEW(lib, anim.first);
 	SET_CAPI_STRING_VIEW(name, anim.second);
-	return true;
 }
 
 OMP_CAPI(Player_EditAttachedObject, void(objectPtr player, int index))
@@ -707,10 +702,9 @@ OMP_CAPI(Player_UseStuntBonuses, void(objectPtr player, bool enable))
 	player_->useStuntBonuses(enable);
 }
 
-OMP_CAPI(All_EnableStuntBonus, bool(bool enable))
+OMP_CAPI(All_EnableStuntBonus, void(bool enable))
 {
 	ComponentManager::Get()->core->useStuntBonuses(enable);
-	return true;
 }
 
 OMP_CAPI(Player_GetArmedWeaponAmmo, int(objectPtr player))
@@ -810,12 +804,11 @@ OMP_CAPI(Player_AttachCameraToObject, void(objectPtr player, objectPtr object))
 	player_->attachCameraToObject(*object_);
 }
 
-OMP_CAPI(Player_AttachCameraToPlayerObject, bool(objectPtr player, objectPtr object))
+OMP_CAPI(Player_AttachCameraToPlayerObject, void(objectPtr player, objectPtr object))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerObjectData, IPlayerObject, object, object_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerObjectData, IPlayerObject, object, object_);
 	player_->attachCameraToObject(*object_);
-	return true;
 }
 
 OMP_CAPI(Player_GetKeyData, void(objectPtr player, uint32_t* keys, int16_t* updown, int16_t* leftright))
@@ -1108,20 +1101,15 @@ OMP_CAPI(Player_GetSkillLevel, int(objectPtr player, int skill))
 	return ret;
 }
 
-OMP_CAPI(Player_GetSurfingOffsets, bool(objectPtr player, float* offsetX, float* offsetY, float* offsetZ))
+OMP_CAPI(Player_GetSurfingData, void(objectPtr player, int* type, int* id, float* offsetX, float* offsetY, float* offsetZ))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_,);
 	const PlayerSurfingData& data = player_->getSurfingData();
-	*offsetX = 0.0f;
-	*offsetY = 0.0f;
-	*offsetZ = 0.0f;
-	if (data.type != PlayerSurfingData::Type::None)
-	{
-		*offsetX = data.offset.x;
-		*offsetY = data.offset.y;
-		*offsetZ = data.offset.z;
-	}
-	return true;
+	*type = data.type;
+	*id = data.ID;
+	*offsetX = data.offset.x;
+	*offsetY = data.offset.y;
+	*offsetZ = data.offset.z;
 }
 
 OMP_CAPI(Player_GetRotationQuat, void(objectPtr player, float* x, float* y, float* z, float* w))

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -281,7 +281,7 @@ OMP_CAPI(Player_GiveWeapon, bool(objectPtr player, uint8_t weapon, uint32_t ammo
 	return true;
 }
 
-OMP_CAPI(Player_RemoveWeapon, bool(objectPtr player, int weapon))
+OMP_CAPI(Player_RemoveWeapon, bool(objectPtr player, uint8_t weapon))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->removeWeapon(weapon);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -423,16 +423,6 @@ OMP_CAPI(Player_GetAimData, bool(objectPtr player, float* frontVectorX, float* f
 	return true;
 }
 
-OMP_CAPI(Player_GetCameraPos, bool(objectPtr player, float* x, float* y, float* z))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	auto pos = player_->getAimData().camPos;
-	*x = pos.x;
-	*y = pos.y;
-	*z = pos.z;
-	return true;
-}
-
 OMP_CAPI(Player_GetDistanceFromPoint, float(objectPtr player, float x, float y, float z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0.0f);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -778,6 +778,14 @@ OMP_CAPI(Player_GetArmedWeaponAmmo, int(objectPtr player))
 	return ammo;
 }
 
+OMP_CAPI(Player_GetAnimationData, void(objectPtr player, uint16_t* id, uint16_t* flags))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	auto data = player_->getAnimationData();
+	*id = data.ID;
+	*flags = data.flags;
+}
+
 OMP_CAPI(Player_GetAnimationIndex, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -819,7 +819,7 @@ OMP_CAPI(Player_GetVehicleSeat, int(objectPtr player))
 	return seat;
 }
 
-OMP_CAPI(Player_GetWeaponData, bool(objectPtr player, int slot, int* weaponid, int* ammo))
+OMP_CAPI(Player_GetWeaponSlot, bool(objectPtr player, int slot, int* weaponid, int* ammo))
 {
 	if (slot < 0 || slot >= MAX_WEAPON_SLOTS)
 	{

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1017,7 +1017,7 @@ OMP_CAPI(Player_SetFacingAngle, bool(objectPtr player, float angle))
 	return true;
 }
 
-OMP_CAPI(Player_SetMarkerForPlayer, bool(objectPtr player, objectPtr other, uint32_t color))
+OMP_CAPI(Player_SetOtherColor, bool(objectPtr player, objectPtr other, uint32_t color))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, other, other_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1190,7 +1190,7 @@ OMP_CAPI(Player_SendEmptyDeathMessage, void(objectPtr player))
 	player_->sendEmptyDeathMessage();
 }
 
-OMP_CAPI(Player_SendMessageToPlayer, bool(objectPtr player, objectPtr sender, StringCharPtr message))
+OMP_CAPI(Player_SendChatMessage, bool(objectPtr player, objectPtr sender, StringCharPtr message))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, sender, sender_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -543,13 +543,6 @@ OMP_CAPI(Player_SetWorldBounds, bool(objectPtr player, float xMax, float xMin, f
 	return true;
 }
 
-OMP_CAPI(Player_ClearWorldBounds, bool(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	player_->setWorldBounds(Vector4(MAX_WORLD_BOUNDS, MIN_WORLD_BOUNDS, MAX_WORLD_BOUNDS, MIN_WORLD_BOUNDS));
-	return true;
-}
-
 OMP_CAPI(Player_GetWorldBounds, bool(objectPtr player, float* xmax, float* xmin, float* ymax, float* ymin))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -752,7 +752,7 @@ OMP_CAPI(All_EnableStuntBonus, bool(bool enable))
 	return true;
 }
 
-OMP_CAPI(Player_GetPlayerAmmo, int(objectPtr player))
+OMP_CAPI(Player_GetArmedWeaponAmmo, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	int ammo = player_->getArmedWeaponAmmo();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -58,7 +58,7 @@ OMP_CAPI(Player_SetInterior, bool(objectPtr player, int interior))
 	return true;
 }
 
-OMP_CAPI(Player_SetWantedLevel, bool(objectPtr player, int level))
+OMP_CAPI(Player_SetWantedLevel, bool(objectPtr player, unsigned int level))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setWantedLevel(level);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -758,7 +758,7 @@ OMP_CAPI(Player_EnableCameraTarget, bool(objectPtr player, bool enable))
 	return true;
 }
 
-OMP_CAPI(Player_EnableStuntBonuses, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_UseStuntBonuses, bool(objectPtr player, bool enable))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->useStuntBonuses(enable);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1025,18 +1025,13 @@ OMP_CAPI(Player_SetOtherColor, bool(objectPtr player, objectPtr other, uint32_t 
 	return true;
 }
 
-OMP_CAPI(Player_GetMarkerForPlayer, uint32_t(objectPtr player, objectPtr other))
+OMP_CAPI(Player_GetMarkerForPlayer, bool(objectPtr player, objectPtr other))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	ENTITY_CAST_RET(IPlayer, other, other_, 0);
+	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	ENTITY_CAST_RET(IPlayer, other, other_, false);
 	Colour color;
 	bool hasPlayerSpecificColor = player_->getOtherColour(*other_, color);
-	if (!hasPlayerSpecificColor)
-	{
-		color = other_->getColour();
-	}
-	uint32_t rgba = color.RGBA();
-	return rgba;
+	return hasPlayerSpecificColor;
 }
 
 OMP_CAPI(Player_AllowTeleport, bool(objectPtr player, bool allow))

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -500,6 +500,12 @@ OMP_CAPI(Player_PlaySound, bool(objectPtr player, uint32_t sound, float x, float
 	return true;
 }
 
+OMP_CAPI(Player_LastPlayedSound, uint32_t(objectPtr player))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	return player_->lastPlayedSound();
+}
+
 OMP_CAPI(Player_SpectatePlayer, bool(objectPtr player, objectPtr target, int mode))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -786,13 +786,6 @@ OMP_CAPI(Player_GetAnimationData, void(objectPtr player, uint16_t* id, uint16_t*
 	*flags = data.flags;
 }
 
-OMP_CAPI(Player_GetAnimationIndex, int(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	int id = player_->getAnimationData().ID;
-	return id;
-}
-
 OMP_CAPI(Player_GetFacingAngle, float(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0.0f);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -639,7 +639,7 @@ OMP_CAPI(Player_RemoveFromVehicle, bool(objectPtr player, bool force))
 	return true;
 }
 
-OMP_CAPI(Player_RemoveMapIcon, bool(objectPtr player, int icon))
+OMP_CAPI(Player_UnsetMapIcon, bool(objectPtr player, int icon))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->unsetMapIcon(icon);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -146,7 +146,7 @@ OMP_CAPI(All_SendDeathMessage, void(objectPtr killer, objectPtr killee, int weap
 	if (killee)
 	{
 		POOL_ENTITY(players, IPlayer, killer, killer_);
-		ENTITY_CAST(IPlayer, killee, killee_,);
+		ENTITY_CAST(IPlayer, killee, killee_);
 		ComponentManager::Get()->players->sendDeathMessageToAll(killer_, *killee_, weapon);
 	}
 	else
@@ -1103,9 +1103,9 @@ OMP_CAPI(Player_GetSkillLevel, int(objectPtr player, int skill))
 
 OMP_CAPI(Player_GetSurfingData, void(objectPtr player, int* type, int* id, float* offsetX, float* offsetY, float* offsetZ))
 {
-	POOL_ENTITY(players, IPlayer, player, player_,);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	const PlayerSurfingData& data = player_->getSurfingData();
-	*type = data.type;
+	*type = int(data.type);
 	*id = data.ID;
 	*offsetX = data.offset.x;
 	*offsetY = data.offset.y;
@@ -1325,7 +1325,7 @@ OMP_CAPI(Player_GetCheckpoint, objectPtr(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
 	PLAYER_DATA_RET(player_, IPlayerCheckpointData, data, nullptr);
-	const ICheckpointData& cp = data->getCheckpoint();
+	ICheckpointData& cp = data->getCheckpoint();
 	return &cp;
 }
 
@@ -1334,6 +1334,6 @@ OMP_CAPI(Player_GetRaceCheckpoint, objectPtr(objectPtr player))
 	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
 	PLAYER_DATA_RET(player_, IPlayerCheckpointData, data, nullptr);
 	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player_);
-	const IRaceCheckpointData& cp = playerData->getRaceCheckpoint();
+	IRaceCheckpointData& cp = playerData->getRaceCheckpoint();
 	return &cp;
 }

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1084,7 +1084,7 @@ OMP_CAPI(Player_Spawn, bool(objectPtr player))
 	return true;
 }
 
-OMP_CAPI(Player_GPCI, bool(objectPtr player, OutputStringViewPtr gpci))
+OMP_CAPI(Player_GetSerial, bool(objectPtr player, OutputStringViewPtr gpci))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	auto result = player_->getSerial();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1168,7 +1168,7 @@ OMP_CAPI(Player_BanEx, bool(objectPtr player, StringCharPtr reason))
 	return true;
 }
 
-OMP_CAPI(Player_SendDeathMessage, bool(objectPtr player, objectPtr killer, objectPtr killee, int weapon))
+OMP_CAPI(Player_SendDeathMessage, bool(objectPtr player, objectPtr killee, objectPtr killer, int weapon))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, killee, killee_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -295,6 +295,12 @@ OMP_CAPI(Player_RemoveWeapon, bool(objectPtr player, uint8_t weapon))
 	return true;
 }
 
+OMP_CAPI(Player_SetMoney, void(objectPtr player, int money))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	player_->setMoney(money);
+}
+
 OMP_CAPI(Player_GetMoney, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1172,15 +1172,8 @@ OMP_CAPI(Player_SendDeathMessage, bool(objectPtr player, objectPtr killee, objec
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, killee, killee_, false);
-	if (killee_)
-	{
-		ENTITY_CAST_RET(IPlayer, killer, killer_, false);
-		player_->sendDeathMessage(*killee_, killer_, weapon);
-	}
-	else
-	{
-		player_->sendEmptyDeathMessage();
-	}
+	ENTITY_CAST_RET(IPlayer, killer, killer_, false);
+	player_->sendDeathMessage(*killee_, killer_, weapon);
 	return true;
 }
 

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -179,7 +179,7 @@ OMP_CAPI(Player_UseWidescreen, bool(objectPtr player, bool enable))
 	return true;
 }
 
-OMP_CAPI(Player_IsWidescreenToggled, bool(objectPtr player))
+OMP_CAPI(Player_HasWidescreen, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	auto enabled = player_->hasWidescreen();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1207,13 +1207,11 @@ OMP_CAPI(Player_SendMessageToPlayer, bool(objectPtr player, objectPtr sender, St
 	return true;
 }
 
-OMP_CAPI(Player_GetClientVersionName, int(objectPtr player, OutputStringViewPtr version))
+OMP_CAPI(Player_GetClientVersionName, void(objectPtr player, OutputStringViewPtr version))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto versionStr = player_->getClientVersionName();
-	auto len = versionStr.length();
-	COPY_STRING_TO_CAPI_STRING_VIEW(version, versionStr.data(), len);
-	return len;
+	COPY_STRING_TO_CAPI_STRING_VIEW(version, versionStr.data(), versionStr.length());
 }
 
 OMP_CAPI(Player_GetSkillLevel, int(objectPtr player, int skill))

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1203,13 +1203,6 @@ OMP_CAPI(Player_GetSkillLevel, int(objectPtr player, int skill))
 	return ret;
 }
 
-OMP_CAPI(Player_GetZAim, float(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0.0f);
-	float z = player_->getAimData().aimZ;
-	return z;
-}
-
 OMP_CAPI(Player_GetSurfingOffsets, bool(objectPtr player, float* offsetX, float* offsetY, float* offsetZ))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -861,13 +861,6 @@ OMP_CAPI(Player_AttachCameraToPlayerObject, bool(objectPtr player, objectPtr obj
 	return true;
 }
 
-OMP_CAPI(Player_GetCameraAspectRatio, float(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0.0f);
-	float ratio = player_->getAimData().aspectRatio;
-	return ratio;
-}
-
 OMP_CAPI(Player_GetCameraFrontVector, bool(objectPtr player, float* x, float* y, float* z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -777,10 +777,6 @@ OMP_CAPI(Player_GetVehicleSeat, int(objectPtr player))
 
 OMP_CAPI(Player_GetWeaponSlot, void(objectPtr player, int slot, uint8_t* weapon, uint32_t* ammo))
 {
-	if (slot < 0 || slot >= MAX_WEAPON_SLOTS)
-	{
-		return;
-	}
 	POOL_ENTITY(players, IPlayer, player, player_);
 	const WeaponSlotData& weaponSlot = player_->getWeaponSlot(slot);
 	*weapon = weaponSlot.id;

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -93,6 +93,13 @@ OMP_CAPI(Player_SetShopName, bool(objectPtr player, StringCharPtr name))
 	return true;
 }
 
+OMP_CAPI(Player_GetShopName, void(objectPtr player, OutputStringViewPtr name))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	auto result = player_->getShopName();
+	COPY_STRING_TO_CAPI_STRING_VIEW(name, result.data(), result.length());
+}
+
 OMP_CAPI(Player_GiveMoney, bool(objectPtr player, int amount))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -826,10 +826,9 @@ OMP_CAPI(Player_GetWeaponSlot, bool(objectPtr player, int slot, uint8_t* weapon,
 		return false;
 	}
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	const WeaponSlotData& weapon = player_->getWeaponSlot(slot);
-	*weapon = weapon.id;
-	*ammo = weapon.ammo;
-	return true;
+	const WeaponSlotData& weaponSlot = player_->getWeaponSlot(slot);
+	*weapon = weaponSlot.id;
+	*ammo = weaponSlot.ammo;
 }
 
 OMP_CAPI(Player_InterpolateCameraPosition, bool(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -804,7 +804,7 @@ OMP_CAPI(Player_GetIp, int(objectPtr player, OutputStringViewPtr ip))
 	return 0;
 }
 
-OMP_CAPI(Player_GetSpecialAction, int(objectPtr player))
+OMP_CAPI(Player_GetAction, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	int action = player_->getAction();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -705,7 +705,7 @@ OMP_CAPI(Player_SetSpecialAction, bool(objectPtr player, uint32_t action))
 	return true;
 }
 
-OMP_CAPI(Player_ShowNameTagForPlayer, bool(objectPtr player, objectPtr other, bool enable))
+OMP_CAPI(Player_ToggleOtherNameTag, bool(objectPtr player, objectPtr other, bool enable))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, other, other_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -491,7 +491,7 @@ OMP_CAPI(Player_IsBot, bool(objectPtr player))
 	return bot;
 }
 
-OMP_CAPI(Player_IsStreamedIn, bool(objectPtr player, objectPtr other))
+OMP_CAPI(Player_IsStreamedInForPlayer, bool(objectPtr player, objectPtr other))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	ENTITY_CAST_RET(IPlayer, other, other_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -172,7 +172,7 @@ OMP_CAPI(All_SendDeathMessage, bool(objectPtr killer, objectPtr killee, int weap
 	return true;
 }
 
-OMP_CAPI(Player_ToggleWidescreen, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_UseWidescreen, bool(objectPtr player, bool enable))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->useWidescreen(enable);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -143,7 +143,7 @@ OMP_CAPI(All_CreateExplosion, bool(float x, float y, float z, int type, float ra
 	return true;
 }
 
-OMP_CAPI(Player_PlayAudio, bool(objectPtr player, StringCharPtr url, float x, float y, float z, float distance, bool usePos))
+OMP_CAPI(Player_PlayAudio, bool(objectPtr player, StringCharPtr url, bool usePos, float x, float y, float z, float distance))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->playAudio(url, usePos, { x, y, z }, distance);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -727,7 +727,7 @@ OMP_CAPI(Player_SetSpectating, bool(objectPtr player, bool enable))
 	return true;
 }
 
-OMP_CAPI(Player_ApplyAnimation, bool(objectPtr player, StringCharPtr animlib, StringCharPtr animname, float delta, bool loop, bool lockX, bool lockY, bool freeze, uint32_t time, int sync))
+OMP_CAPI(Player_ApplyAnimation, bool(objectPtr player, float delta, bool loop, bool lockX, bool lockY, bool freeze, uint32_t time, StringCharPtr animlib, StringCharPtr animname, int sync))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	AnimationData animationData(delta, loop, lockX, lockY, freeze, time, animlib, animname);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -454,7 +454,7 @@ OMP_CAPI(Player_GetVirtualWorld, int(objectPtr player))
 	return vw;
 }
 
-OMP_CAPI(Player_IsNPC, bool(objectPtr player))
+OMP_CAPI(Player_IsBot, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	auto bot = player_->isBot();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -861,16 +861,6 @@ OMP_CAPI(Player_AttachCameraToPlayerObject, bool(objectPtr player, objectPtr obj
 	return true;
 }
 
-OMP_CAPI(Player_GetCameraFrontVector, bool(objectPtr player, float* x, float* y, float* z))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	auto vector = player_->getAimData().camFrontVector;
-	*x = vector.x;
-	*y = vector.y;
-	*z = vector.z;
-	return true;
-}
-
 OMP_CAPI(Player_GetKeys, bool(objectPtr player, int* keys, int* updown, int* leftright))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -453,7 +453,7 @@ OMP_CAPI(Player_GetDistanceFromPoint, float(objectPtr player, float x, float y, 
 	return distance;
 }
 
-OMP_CAPI(Player_GetInterior, int(objectPtr player))
+OMP_CAPI(Player_GetInterior, unsigned(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	int interior = player_->getInterior();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -819,7 +819,7 @@ OMP_CAPI(Player_GetVehicleSeat, int(objectPtr player))
 	return seat;
 }
 
-OMP_CAPI(Player_GetWeaponSlot, bool(objectPtr player, int slot, int* weaponid, int* ammo))
+OMP_CAPI(Player_GetWeaponSlot, bool(objectPtr player, int slot, uint8_t* weapon, uint32_t* ammo))
 {
 	if (slot < 0 || slot >= MAX_WEAPON_SLOTS)
 	{

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -612,7 +612,7 @@ OMP_CAPI(Player_PutInVehicle, bool(objectPtr player, objectPtr vehicle, int seat
 	return true;
 }
 
-OMP_CAPI(Player_RemoveBuilding, bool(objectPtr player, int model, float x, float y, float z, float radius))
+OMP_CAPI(Player_RemoveDefaultObjects, bool(objectPtr player, int model, float x, float y, float z, float radius))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->removeDefaultObjects(model, { x, y, z }, radius);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1045,13 +1045,6 @@ OMP_CAPI(Player_DisableRemoteVehicleCollisions, bool(objectPtr player, bool disa
 	return true;
 }
 
-OMP_CAPI(Player_GetCameraZoom, float(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0.0f);
-	float cameraZoom = player_->getAimData().camZoom;
-	return cameraZoom;
-}
-
 OMP_CAPI(Player_SelectTextDraw, bool(objectPtr player, uint32_t hoverColour))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -871,13 +871,6 @@ OMP_CAPI(Player_GetCameraFrontVector, bool(objectPtr player, float* x, float* y,
 	return true;
 }
 
-OMP_CAPI(Player_GetCameraMode, int(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	int cameraMode = player_->getAimData().camMode;
-	return cameraMode;
-}
-
 OMP_CAPI(Player_GetKeys, bool(objectPtr player, int* keys, int* updown, int* leftright))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -701,7 +701,7 @@ OMP_CAPI(Player_ShowNameTagForPlayer, bool(objectPtr player, objectPtr other, bo
 	return true;
 }
 
-OMP_CAPI(Player_ToggleControllable, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_SetControllable, bool(objectPtr player, bool enable))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setControllable(enable);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -150,7 +150,7 @@ OMP_CAPI(Player_PlayAudio, bool(objectPtr player, StringCharPtr url, bool usePos
 	return true;
 }
 
-OMP_CAPI(Player_StopAudioStream, bool(objectPtr player))
+OMP_CAPI(Player_StopAudio, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->stopAudio();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -612,7 +612,7 @@ OMP_CAPI(Player_PutInVehicle, bool(objectPtr player, objectPtr vehicle, int seat
 	return true;
 }
 
-OMP_CAPI(Player_RemoveDefaultObjects, bool(objectPtr player, int model, float x, float y, float z, float radius))
+OMP_CAPI(Player_RemoveDefaultObjects, bool(objectPtr player, unsigned model, float x, float y, float z, float radius))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->removeDefaultObjects(model, { x, y, z }, radius);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -832,7 +832,7 @@ OMP_CAPI(Player_GetWeaponData, bool(objectPtr player, int slot, int* weaponid, i
 	return true;
 }
 
-OMP_CAPI(Player_InterpolateCameraPos, bool(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))
+OMP_CAPI(Player_InterpolateCameraPosition, bool(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->interpolateCameraPosition({ from_x, from_y, from_z }, { to_x, to_y, to_z }, time, PlayerCameraCutType(cut));

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -691,7 +691,7 @@ OMP_CAPI(Player_SetSkillLevel, bool(objectPtr player, uint8_t weapon, int level)
 	return true;
 }
 
-OMP_CAPI(Player_SetSpecialAction, bool(objectPtr player, uint32_t action))
+OMP_CAPI(Player_SetAction, bool(objectPtr player, uint32_t action))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setAction(PlayerSpecialAction(action));

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -758,7 +758,7 @@ OMP_CAPI(Player_EnableCameraTarget, bool(objectPtr player, bool enable))
 	return true;
 }
 
-OMP_CAPI(Player_EnableStuntBonus, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_EnableStuntBonuses, bool(objectPtr player, bool enable))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->useStuntBonuses(enable);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -708,7 +708,7 @@ OMP_CAPI(Player_SetControllable, bool(objectPtr player, bool enable))
 	return true;
 }
 
-OMP_CAPI(Player_ToggleSpectating, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_SetSpectating, bool(objectPtr player, bool enable))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->setSpectating(enable);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -24,11 +24,10 @@ OMP_CAPI(Player_GetID, int(objectPtr player))
 	return player_->getID();
 }
 
-OMP_CAPI(Player_SendClientMessage, bool(objectPtr player, uint32_t color, StringCharPtr text))
+OMP_CAPI(Player_SendClientMessage, void(objectPtr player, uint32_t color, StringCharPtr text))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->sendClientMessage(Colour::FromRGBA(color), text);
-	return true;
 }
 
 OMP_CAPI(All_SendClientMessage, bool(uint32_t color, StringCharPtr text))
@@ -37,39 +36,34 @@ OMP_CAPI(All_SendClientMessage, bool(uint32_t color, StringCharPtr text))
 	return true;
 }
 
-OMP_CAPI(Player_SetCameraPosition, bool(objectPtr player, float x, float y, float z))
+OMP_CAPI(Player_SetCameraPosition, void(objectPtr player, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setCameraPosition({ x, y, z });
-	return true;
 }
 
-OMP_CAPI(Player_SetDrunkLevel, bool(objectPtr player, int level))
+OMP_CAPI(Player_SetDrunkLevel, void(objectPtr player, int level))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setDrunkLevel(level);
-	return true;
 }
 
-OMP_CAPI(Player_SetInterior, bool(objectPtr player, unsigned interior))
+OMP_CAPI(Player_SetInterior, void(objectPtr player, unsigned interior))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setInterior(interior);
-	return true;
 }
 
-OMP_CAPI(Player_SetWantedLevel, bool(objectPtr player, unsigned int level))
+OMP_CAPI(Player_SetWantedLevel, void(objectPtr player, unsigned int level))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setWantedLevel(level);
-	return true;
 }
 
-OMP_CAPI(Player_SetWeather, bool(objectPtr player, int weather))
+OMP_CAPI(Player_SetWeather, void(objectPtr player, int weather))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setWeather(weather);
-	return true;
 }
 
 OMP_CAPI(Player_GetWeather, int(objectPtr player))
@@ -79,18 +73,16 @@ OMP_CAPI(Player_GetWeather, int(objectPtr player))
 	return weather;
 }
 
-OMP_CAPI(Player_SetSkin, bool(objectPtr player, int skin))
+OMP_CAPI(Player_SetSkin, void(objectPtr player, int skin))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setSkin(skin);
-	return true;
 }
 
-OMP_CAPI(Player_SetShopName, bool(objectPtr player, StringCharPtr name))
+OMP_CAPI(Player_SetShopName, void(objectPtr player, StringCharPtr name))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setShopName(name);
-	return true;
 }
 
 OMP_CAPI(Player_GetShopName, void(objectPtr player, OutputStringViewPtr name))
@@ -100,18 +92,16 @@ OMP_CAPI(Player_GetShopName, void(objectPtr player, OutputStringViewPtr name))
 	COPY_STRING_TO_CAPI_STRING_VIEW(name, result.data(), result.length());
 }
 
-OMP_CAPI(Player_GiveMoney, bool(objectPtr player, int amount))
+OMP_CAPI(Player_GiveMoney, void(objectPtr player, int amount))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->giveMoney(amount);
-	return true;
 }
 
-OMP_CAPI(Player_SetCameraLookAt, bool(objectPtr player, float x, float y, float z, int cutType))
+OMP_CAPI(Player_SetCameraLookAt, void(objectPtr player, float x, float y, float z, int cutType))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setCameraLookAt({ x, y, z }, cutType);
-	return true;
 }
 
 OMP_CAPI(Player_GetCameraLookAt, void(objectPtr player, float* x, float* y, float* z))
@@ -123,18 +113,16 @@ OMP_CAPI(Player_GetCameraLookAt, void(objectPtr player, float* x, float* y, floa
 	*z = pos.z;
 }
 
-OMP_CAPI(Player_SetCameraBehind, bool(objectPtr player))
+OMP_CAPI(Player_SetCameraBehind, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setCameraBehind();
-	return true;
 }
 
-OMP_CAPI(Player_CreateExplosion, bool(objectPtr player, float x, float y, float z, int type, float radius))
+OMP_CAPI(Player_CreateExplosion, void(objectPtr player, float x, float y, float z, int type, float radius))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->createExplosion({ x, y, z }, type, radius);
-	return true;
 }
 
 OMP_CAPI(All_CreateExplosion, bool(float x, float y, float z, int type, float radius))
@@ -143,18 +131,16 @@ OMP_CAPI(All_CreateExplosion, bool(float x, float y, float z, int type, float ra
 	return true;
 }
 
-OMP_CAPI(Player_PlayAudio, bool(objectPtr player, StringCharPtr url, bool usePos, float x, float y, float z, float distance))
+OMP_CAPI(Player_PlayAudio, void(objectPtr player, StringCharPtr url, bool usePos, float x, float y, float z, float distance))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->playAudio(url, usePos, { x, y, z }, distance);
-	return true;
 }
 
-OMP_CAPI(Player_StopAudio, bool(objectPtr player))
+OMP_CAPI(Player_StopAudio, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->stopAudio();
-	return true;
 }
 
 OMP_CAPI(All_SendDeathMessage, bool(objectPtr killer, objectPtr killee, int weapon))
@@ -172,11 +158,10 @@ OMP_CAPI(All_SendDeathMessage, bool(objectPtr killer, objectPtr killee, int weap
 	return true;
 }
 
-OMP_CAPI(Player_UseWidescreen, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_UseWidescreen, void(objectPtr player, bool enable))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->useWidescreen(enable);
-	return true;
 }
 
 OMP_CAPI(Player_HasWidescreen, bool(objectPtr player))
@@ -186,11 +171,10 @@ OMP_CAPI(Player_HasWidescreen, bool(objectPtr player))
 	return enabled;
 }
 
-OMP_CAPI(Player_SetHealth, bool(objectPtr player, float health))
+OMP_CAPI(Player_SetHealth, void(objectPtr player, float health))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setHealth(health);
-	return true;
 }
 
 OMP_CAPI(Player_GetHealth, float(objectPtr player))
@@ -200,11 +184,10 @@ OMP_CAPI(Player_GetHealth, float(objectPtr player))
 	return health;
 }
 
-OMP_CAPI(Player_SetArmor, bool(objectPtr player, float armor))
+OMP_CAPI(Player_SetArmor, void(objectPtr player, float armor))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setArmour(armor);
-	return true;
 }
 
 OMP_CAPI(Player_GetArmor, float(objectPtr player))
@@ -214,11 +197,10 @@ OMP_CAPI(Player_GetArmor, float(objectPtr player))
 	return armor;
 }
 
-OMP_CAPI(Player_SetTeam, bool(objectPtr player, int team))
+OMP_CAPI(Player_SetTeam, void(objectPtr player, int team))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setTeam(team);
-	return true;
 }
 
 OMP_CAPI(Player_GetTeam, int(objectPtr player))
@@ -228,11 +210,10 @@ OMP_CAPI(Player_GetTeam, int(objectPtr player))
 	return team;
 }
 
-OMP_CAPI(Player_SetScore, bool(objectPtr player, int score))
+OMP_CAPI(Player_SetScore, void(objectPtr player, int score))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setScore(score);
-	return true;
 }
 
 OMP_CAPI(Player_GetScore, int(objectPtr player))
@@ -249,11 +230,10 @@ OMP_CAPI(Player_GetSkin, int(objectPtr player))
 	return skin;
 }
 
-OMP_CAPI(Player_SetColor, bool(objectPtr player, uint32_t color))
+OMP_CAPI(Player_SetColor, void(objectPtr player, uint32_t color))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setColour(Colour::FromRGBA(color));
-	return true;
 }
 
 OMP_CAPI(Player_GetColor, uint32_t(objectPtr player))
@@ -278,21 +258,19 @@ OMP_CAPI(Player_GetDrunkLevel, int(objectPtr player))
 	return level;
 }
 
-OMP_CAPI(Player_GiveWeapon, bool(objectPtr player, uint8_t weapon, uint32_t ammo))
+OMP_CAPI(Player_GiveWeapon, void(objectPtr player, uint8_t weapon, uint32_t ammo))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	WeaponSlotData data;
 	data.id = weapon;
 	data.ammo = ammo;
 	player_->giveWeapon(data);
-	return true;
 }
 
-OMP_CAPI(Player_RemoveWeapon, bool(objectPtr player, uint8_t weapon))
+OMP_CAPI(Player_RemoveWeapon, void(objectPtr player, uint8_t weapon))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->removeWeapon(weapon);
-	return true;
 }
 
 OMP_CAPI(Player_SetMoney, void(objectPtr player, int money))
@@ -308,11 +286,10 @@ OMP_CAPI(Player_GetMoney, int(objectPtr player))
 	return money;
 }
 
-OMP_CAPI(Player_ResetMoney, bool(objectPtr player))
+OMP_CAPI(Player_ResetMoney, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->resetMoney();
-	return true;
 }
 
 OMP_CAPI(Player_SetName, int(objectPtr player, StringCharPtr name))
@@ -322,13 +299,11 @@ OMP_CAPI(Player_SetName, int(objectPtr player, StringCharPtr name))
 	return status;
 }
 
-OMP_CAPI(Player_GetName, int(objectPtr player, OutputStringViewPtr name))
+OMP_CAPI(Player_GetName, void(objectPtr player, OutputStringViewPtr name))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto result = player_->getName();
-	int len = result.length();
-	COPY_STRING_TO_CAPI_STRING_VIEW(name, result.data(), len);
-	return len;
+	COPY_STRING_TO_CAPI_STRING_VIEW(name, result.data(), result.length());
 }
 
 OMP_CAPI(Player_GetState, int(objectPtr player))
@@ -352,27 +327,30 @@ OMP_CAPI(Player_GetArmedWeapon, uint32_t(objectPtr player))
 	return weapon;
 }
 
-OMP_CAPI(Player_SetTime, bool(objectPtr player, int hour, int minute))
+OMP_CAPI(Player_SetTime, void(objectPtr player, int hour, int minute))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setTime(std::chrono::hours(hour), std::chrono::minutes(minute));
-	return true;
 }
 
-OMP_CAPI(Player_GetTime, bool(objectPtr player, int* hour, int* minute))
+OMP_CAPI(Player_GetTime, void(objectPtr player, int* hour, int* minute))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto data = player_->getTime();
 	*hour = data.first.count();
 	*minute = data.second.count();
-	return true;
 }
 
-OMP_CAPI(Player_UseClock, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_SetWorldTime, void(objectPtr player, int time))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	player_->setWorldTime(std::chrono::hours(time));
+}
+
+OMP_CAPI(Player_UseClock, void(objectPtr player, bool enable))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->useClock(enable);
-	return true;
 }
 
 OMP_CAPI(Player_HasClock, bool(objectPtr player))
@@ -382,11 +360,10 @@ OMP_CAPI(Player_HasClock, bool(objectPtr player))
 	return enable;
 }
 
-OMP_CAPI(Player_ForceClassSelection, bool(objectPtr player))
+OMP_CAPI(Player_ForceClassSelection, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->forceClassSelection();
-	return true;
 }
 
 OMP_CAPI(Player_GetWantedLevel, unsigned(objectPtr player))
@@ -396,11 +373,10 @@ OMP_CAPI(Player_GetWantedLevel, unsigned(objectPtr player))
 	return wanted;
 }
 
-OMP_CAPI(Player_SetFightingStyle, bool(objectPtr player, int style))
+OMP_CAPI(Player_SetFightingStyle, void(objectPtr player, int style))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setFightingStyle(PlayerFightingStyle(style));
-	return true;
 }
 
 OMP_CAPI(Player_GetFightingStyle, int(objectPtr player))
@@ -410,24 +386,22 @@ OMP_CAPI(Player_GetFightingStyle, int(objectPtr player))
 	return style;
 }
 
-OMP_CAPI(Player_SetVelocity, bool(objectPtr player, float x, float y, float z))
+OMP_CAPI(Player_SetVelocity, void(objectPtr player, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setVelocity({ x, y, z });
-	return true;
 }
 
-OMP_CAPI(Player_GetVelocity, bool(objectPtr player, float* x, float* y, float* z))
+OMP_CAPI(Player_GetVelocity, void(objectPtr player, float* x, float* y, float* z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto velocity = player_->getVelocity();
 	*x = velocity.x;
 	*y = velocity.y;
 	*z = velocity.z;
-	return true;
 }
 
-OMP_CAPI(Player_GetAimData, bool(objectPtr player, float* frontVectorX, float* frontVectorY, float* frontVectorZ, float* posX, float* posY, float* posZ, float* aimZ, float* camZoom, float* aspectRatio, int8_t* weaponState, uiint8_t* camMode))
+OMP_CAPI(Player_GetAimData, bool(objectPtr player, float* frontVectorX, float* frontVectorY, float* frontVectorZ, float* posX, float* posY, float* posZ, float* aimZ, float* camZoom, float* aspectRatio, int8_t* weaponState, uint8_t* camMode))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	auto data = player_->getAimData();
@@ -456,15 +430,14 @@ OMP_CAPI(Player_GetDistanceFromPoint, float(objectPtr player, float x, float y, 
 OMP_CAPI(Player_GetInterior, unsigned(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	int interior = player_->getInterior();
+	unsigned interior = player_->getInterior();
 	return interior;
 }
 
-OMP_CAPI(Player_SetPos, bool(objectPtr player, float x, float y, float z))
+OMP_CAPI(Player_SetPosition, void(objectPtr player, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setPosition({ x, y, z });
-	return true;
 }
 
 OMP_CAPI(Player_GetPos, bool(objectPtr player, float* x, float* y, float* z))
@@ -499,11 +472,10 @@ OMP_CAPI(Player_IsStreamedInForPlayer, bool(objectPtr player, objectPtr other))
 	return streamed;
 }
 
-OMP_CAPI(Player_PlaySound, bool(objectPtr player, uint32_t sound, float x, float y, float z))
+OMP_CAPI(Player_PlaySound, void(objectPtr player, uint32_t sound, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->playSound(sound, { x, y, z });
-	return true;
 }
 
 OMP_CAPI(Player_LastPlayedSound, uint32_t(objectPtr player))
@@ -512,12 +484,11 @@ OMP_CAPI(Player_LastPlayedSound, uint32_t(objectPtr player))
 	return player_->lastPlayedSound();
 }
 
-OMP_CAPI(Player_SpectatePlayer, bool(objectPtr player, objectPtr target, int mode))
+OMP_CAPI(Player_SpectatePlayer, void(objectPtr player, objectPtr target, int mode))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	ENTITY_CAST_RET(IPlayer, target, target_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	ENTITY_CAST(IPlayer, target, target_);
 	player_->spectatePlayer(*target_, PlayerSpectateMode(mode));
-	return true;
 }
 
 OMP_CAPI(Player_SpectateVehicle, bool(objectPtr player, objectPtr target, int mode))
@@ -528,37 +499,33 @@ OMP_CAPI(Player_SpectateVehicle, bool(objectPtr player, objectPtr target, int mo
 	return true;
 }
 
-OMP_CAPI(Player_SetVirtualWorld, bool(objectPtr player, int vw))
+OMP_CAPI(Player_SetVirtualWorld, void(objectPtr player, int vw))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setVirtualWorld(vw);
-	return true;
 }
 
-OMP_CAPI(Player_SetWorldBounds, bool(objectPtr player, float xMax, float xMin, float yMax, float yMin))
+OMP_CAPI(Player_SetWorldBounds, void(objectPtr player, float xMax, float xMin, float yMax, float yMin))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	Vector4 coords = { xMax, xMin, yMax, yMin };
 	player_->setWorldBounds(coords);
-	return true;
 }
 
-OMP_CAPI(Player_GetWorldBounds, bool(objectPtr player, float* xmax, float* xmin, float* ymax, float* ymin))
+OMP_CAPI(Player_GetWorldBounds, void(objectPtr player, float* xmax, float* xmin, float* ymax, float* ymin))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto bounds = player_->getWorldBounds();
 	*xmax = bounds.x;
 	*xmin = bounds.y;
 	*ymax = bounds.z;
 	*ymin = bounds.w;
-	return true;
 }
 
-OMP_CAPI(Player_ClearTasks, bool(objectPtr player, int syncType))
+OMP_CAPI(Player_ClearTasks, void(objectPtr player, int syncType))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->clearTasks(PlayerAnimationSyncType(syncType));
-	return true;
 }
 
 OMP_CAPI(Player_GetLastShotVectors, bool(objectPtr player, float* origin_x, float* origin_y, float* origin_z, float* hit_x, float* hit_y, float* hit_z))
@@ -611,49 +578,43 @@ OMP_CAPI(Player_PutInVehicle, bool(objectPtr player, objectPtr vehicle, int seat
 	return true;
 }
 
-OMP_CAPI(Player_RemoveDefaultObjects, bool(objectPtr player, unsigned model, float x, float y, float z, float radius))
+OMP_CAPI(Player_RemoveDefaultObjects, void(objectPtr player, unsigned model, float x, float y, float z, float radius))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->removeDefaultObjects(model, { x, y, z }, radius);
-	return true;
 }
 
-OMP_CAPI(Player_GetBuildingsRemoved, int(objectPtr player))
+OMP_CAPI(Player_GetDefaultObjectsRemoved, int(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	int count = player_->getDefaultObjectsRemoved();
-	return count;
+	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	return player_->getDefaultObjectsRemoved();
 }
 
-OMP_CAPI(Player_RemoveFromVehicle, bool(objectPtr player, bool force))
+OMP_CAPI(Player_RemoveFromVehicle, void(objectPtr player, bool force))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->removeFromVehicle(force);
-	return true;
 }
 
-OMP_CAPI(Player_UnsetMapIcon, bool(objectPtr player, int icon))
+OMP_CAPI(Player_UnsetMapIcon, void(objectPtr player, int icon))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->unsetMapIcon(icon);
-	return true;
 }
 
-OMP_CAPI(Player_SetMapIcon, bool(objectPtr player, int iconID, float x, float y, float z, int type, uint32_t color, int style))
+OMP_CAPI(Player_SetMapIcon, void(objectPtr player, int iconID, float x, float y, float z, int type, uint32_t color, int style))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setMapIcon(iconID, { x, y, z }, type, Colour::FromRGBA(color), MapIconStyle(style));
-	return true;
 }
 
-OMP_CAPI(Player_ResetWeapons, bool(objectPtr player))
+OMP_CAPI(Player_ResetWeapons, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->resetWeapons();
-	return true;
 }
 
-OMP_CAPI(Player_SetAmmo, bool(objectPtr player, uint8_t id, uint32_t ammo))
+OMP_CAPI(Player_SetWeaponAmmo, bool(objectPtr player, uint8_t id, uint32_t ammo))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	WeaponSlotData data;
@@ -663,69 +624,60 @@ OMP_CAPI(Player_SetAmmo, bool(objectPtr player, uint8_t id, uint32_t ammo))
 	return true;
 }
 
-OMP_CAPI(Player_SetArmedWeapon, bool(objectPtr player, uint32_t weapon))
+OMP_CAPI(Player_SetArmedWeapon, void(objectPtr player, uint32_t weapon))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setArmedWeapon(weapon);
-	return true;
 }
 
-OMP_CAPI(Player_SetChatBubble, bool(objectPtr player, StringCharPtr text, uint32_t color, float drawdistance, int expiretime))
+OMP_CAPI(Player_SetChatBubble, void(objectPtr player, StringCharPtr text, uint32_t color, float drawdistance, int expiretime))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setChatBubble(text, Colour::FromRGBA(color), drawdistance, std::chrono::milliseconds(expiretime));
-	return true;
 }
 
-OMP_CAPI(Player_SetPositionFindZ, bool(objectPtr player, float x, float y, float z))
+OMP_CAPI(Player_SetPositionFindZ, void(objectPtr player, float x, float y, float z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setPositionFindZ({ x, y, z });
-	return true;
 }
 
-OMP_CAPI(Player_SetSkillLevel, bool(objectPtr player, uint8_t weapon, int level))
+OMP_CAPI(Player_SetSkillLevel, void(objectPtr player, uint8_t weapon, int level))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setSkillLevel(PlayerWeaponSkill(weapon), level);
-	return true;
 }
 
-OMP_CAPI(Player_SetAction, bool(objectPtr player, int action))
+OMP_CAPI(Player_SetAction, void(objectPtr player, int action))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setAction(PlayerSpecialAction(action));
-	return true;
 }
 
-OMP_CAPI(Player_ToggleOtherNameTag, bool(objectPtr player, objectPtr other, bool enable))
+OMP_CAPI(Player_ToggleOtherNameTag, void(objectPtr player, objectPtr other, bool enable))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	ENTITY_CAST_RET(IPlayer, other, other_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	ENTITY_CAST(IPlayer, other, other_);
 	player_->toggleOtherNameTag(*other_, enable);
-	return true;
 }
 
-OMP_CAPI(Player_SetControllable, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_SetControllable, void(objectPtr player, bool enable))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setControllable(enable);
-	return true;
 }
 
-OMP_CAPI(Player_SetSpectating, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_SetSpectating, void(objectPtr player, bool enable))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setSpectating(enable);
-	return true;
 }
 
-OMP_CAPI(Player_ApplyAnimation, bool(objectPtr player, float delta, bool loop, bool lockX, bool lockY, bool freeze, uint32_t time, StringCharPtr animlib, StringCharPtr animname, int sync))
+OMP_CAPI(Player_ApplyAnimation, void(objectPtr player, float delta, bool loop, bool lockX, bool lockY, bool freeze, uint32_t time, StringCharPtr animlib, StringCharPtr animname, int sync))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	AnimationData animationData(delta, loop, lockX, lockY, freeze, time, animlib, animname);
 	player_->applyAnimation(animationData, PlayerAnimationSyncType(sync));
-	return true;
 }
 
 OMP_CAPI(Player_GetAnimationName, bool(int index, OutputStringViewPtr lib, OutputStringViewPtr name))
@@ -736,26 +688,23 @@ OMP_CAPI(Player_GetAnimationName, bool(int index, OutputStringViewPtr lib, Outpu
 	return true;
 }
 
-OMP_CAPI(Player_EditAttachedObject, bool(objectPtr player, int index))
+OMP_CAPI(Player_EditAttachedObject, void(objectPtr player, int index))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerObjectData, data, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
 	data->editAttachedObject(index);
-	return true;
 }
 
-OMP_CAPI(Player_EnableCameraTarget, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_UseCameraTargetting, void(objectPtr player, bool enable))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->useCameraTargeting(enable);
-	return true;
 }
 
-OMP_CAPI(Player_UseStuntBonuses, bool(objectPtr player, bool enable))
+OMP_CAPI(Player_UseStuntBonuses, void(objectPtr player, bool enable))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->useStuntBonuses(enable);
-	return true;
 }
 
 OMP_CAPI(All_EnableStuntBonus, bool(bool enable))
@@ -787,9 +736,9 @@ OMP_CAPI(Player_GetFacingAngle, float(objectPtr player))
 	return angle;
 }
 
-OMP_CAPI(Player_GetIp, int(objectPtr player, OutputStringViewPtr ip))
+OMP_CAPI(Player_GetIp, void(objectPtr player, OutputStringViewPtr ip))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	PeerNetworkData data = player_->getNetworkData();
 	if (!data.networkID.address.ipv6)
 	{
@@ -798,10 +747,10 @@ OMP_CAPI(Player_GetIp, int(objectPtr player, OutputStringViewPtr ip))
 		{
 			auto len = addressString.length();
 			COPY_STRING_TO_CAPI_STRING_VIEW(ip, addressString.data(), len);
-			return len;
+			return;
 		}
 	}
-	return 0;
+	return;
 }
 
 OMP_CAPI(Player_GetAction, int(objectPtr player))
@@ -811,67 +760,58 @@ OMP_CAPI(Player_GetAction, int(objectPtr player))
 	return action;
 }
 
-OMP_CAPI(Player_GetVehicleID, int(objectPtr player))
+OMP_CAPI(Player_GetVehicle, objectPtr(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, INVALID_VEHICLE_ID);
-	PLAYER_DATA_RET(player_, IPlayerVehicleData, data, INVALID_VEHICLE_ID);
+	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
+	PLAYER_DATA_RET(player_, IPlayerVehicleData, data, nullptr);
 	IVehicle* vehicle = data->getVehicle();
-	int id = 0;
-	if (vehicle)
-	{
-		id = vehicle->getID();
-	}
-	return id;
+	return vehicle;
 }
 
 OMP_CAPI(Player_GetVehicleSeat, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	PLAYER_DATA_RET(player_, IPlayerVehicleData, data, 0);
-	int seat = data->getSeat();
-	return seat;
+	return data->getSeat();
 }
 
-OMP_CAPI(Player_GetWeaponSlot, bool(objectPtr player, int slot, uint8_t* weapon, uint32_t* ammo))
+OMP_CAPI(Player_GetWeaponSlot, void(objectPtr player, int slot, uint8_t* weapon, uint32_t* ammo))
 {
 	if (slot < 0 || slot >= MAX_WEAPON_SLOTS)
 	{
-		return false;
+		return;
 	}
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	const WeaponSlotData& weaponSlot = player_->getWeaponSlot(slot);
 	*weapon = weaponSlot.id;
 	*ammo = weaponSlot.ammo;
 }
 
-OMP_CAPI(Player_InterpolateCameraPosition, bool(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))
+OMP_CAPI(Player_InterpolateCameraPosition, void(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->interpolateCameraPosition({ from_x, from_y, from_z }, { to_x, to_y, to_z }, time, PlayerCameraCutType(cut));
-	return true;
 }
 
-OMP_CAPI(Player_InterpolateCameraLookAt, bool(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))
+OMP_CAPI(Player_InterpolateCameraLookAt, void(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	player_->interpolateCameraLookAt({ from_x, from_y, from_z }, { to_x, to_y, to_z }, time, PlayerCameraCutType(cut));
+}
+
+OMP_CAPI(Player_HasAttachedObject, bool(objectPtr player, int index))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	player_->interpolateCameraLookAt({ from_x, from_y, from_z }, { to_x, to_y, to_z }, time, PlayerCameraCutType(cut));
-	return true;
-}
-
-OMP_CAPI(Player_IsPlayerAttachedObjectSlotUsed, bool(objectPtr player, int index))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	PLAYER_DATA_RET(player_, IPlayerObjectData, data, 0);
+	PLAYER_DATA_RET(player_, IPlayerObjectData, data, false);
 	bool ret = data->hasAttachedObject(index);
 	return ret;
 }
 
-OMP_CAPI(Player_AttachCameraToObject, bool(objectPtr player, objectPtr object))
+OMP_CAPI(Player_AttachCameraToObject, void(objectPtr player, objectPtr object))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	POOL_ENTITY_RET(objects, IObject, object, object_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	POOL_ENTITY(objects, IObject, object, object_);
 	player_->attachCameraToObject(*object_);
-	return true;
 }
 
 OMP_CAPI(Player_AttachCameraToPlayerObject, bool(objectPtr player, objectPtr object))
@@ -882,14 +822,13 @@ OMP_CAPI(Player_AttachCameraToPlayerObject, bool(objectPtr player, objectPtr obj
 	return true;
 }
 
-OMP_CAPI(Player_GetKeys, bool(objectPtr player, int* keys, int* updown, int* leftright))
+OMP_CAPI(Player_GetKeyData, void(objectPtr player, uint32_t* keys, int16_t* updown, int16_t* leftright))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	const PlayerKeyData& keyData = player_->getKeyData();
 	*keys = keyData.keys;
 	*updown = keyData.upDown;
 	*leftright = keyData.leftRight;
-	return true;
 }
 
 OMP_CAPI(Player_GetSurfingVehicle, objectPtr(objectPtr player))
@@ -935,25 +874,6 @@ OMP_CAPI(Player_GetTargetActor, objectPtr(objectPtr player))
 	return player_->getTargetActor();
 }
 
-OMP_CAPI(Player_IsInVehicle, bool(objectPtr player, objectPtr targetVehicle))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerVehicleData, data, false);
-	POOL_ENTITY_RET(vehicles, IVehicle, targetVehicle, targetVehicle_, false);
-	IVehicle* vehicle = data->getVehicle();
-	bool ret = bool(vehicle == targetVehicle_);
-	return ret;
-}
-
-OMP_CAPI(Player_IsInAnyVehicle, bool(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerVehicleData, data, false);
-	IVehicle* vehicle = data->getVehicle();
-	bool ret = bool(vehicle != nullptr);
-	return ret;
-}
-
 OMP_CAPI(Player_IsInRangeOfPoint, bool(objectPtr player, float range, float x, float y, float z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
@@ -968,18 +888,17 @@ OMP_CAPI(Player_PlayCrimeReport, bool(objectPtr player, objectPtr suspect, int c
 	return player_->playerCrimeReport(*suspect_, crime);
 }
 
-OMP_CAPI(Player_RemoveAttachedObject, bool(objectPtr player, int index))
+OMP_CAPI(Player_RemoveAttachedObject, void(objectPtr player, int index))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerObjectData, data, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
 	data->removeAttachedObject(index);
-	return true;
 }
 
-OMP_CAPI(Player_SetAttachedObject, bool(objectPtr player, int index, int modelid, int bone, float offsetX, float offsetY, float offsetZ, float rotationX, float rotationY, float rotationZ, float scaleX, float scaleY, float scaleZ, uint32_t materialcolor1, uint32_t materialcolor2))
+OMP_CAPI(Player_SetAttachedObject, void(objectPtr player, int index, int modelid, int bone, float offsetX, float offsetY, float offsetZ, float rotationX, float rotationY, float rotationZ, float scaleX, float scaleY, float scaleZ, uint32_t materialcolor1, uint32_t materialcolor2))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerObjectData, data, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
 	ObjectAttachmentSlotData attachment;
 	attachment.model = modelid;
 	attachment.bone = bone;
@@ -989,13 +908,12 @@ OMP_CAPI(Player_SetAttachedObject, bool(objectPtr player, int index, int modelid
 	attachment.colour1 = Colour::FromARGB(materialcolor1);
 	attachment.colour2 = Colour::FromARGB(materialcolor2);
 	data->setAttachedObject(index, attachment);
-	return true;
 }
 
-OMP_CAPI(Player_GetAttachedObject, bool(objectPtr player, int index, int* modelid, int* bone, float* offsetX, float* offsetY, float* offsetZ, float* rotationX, float* rotationY, float* rotationZ, float* scaleX, float* scaleY, float* scaleZ, int* materialcolor1, int* materialcolor2))
+OMP_CAPI(Player_GetAttachedObject, void(objectPtr player, int index, int* modelid, int* bone, float* offsetX, float* offsetY, float* offsetZ, float* rotationX, float* rotationY, float* rotationZ, float* scaleX, float* scaleY, float* scaleZ, uint32_t* materialcolor1, uint32_t* materialcolor2))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerObjectData, data, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
 	ObjectAttachmentSlotData attachment = data->getAttachedObject(index);
 	*modelid = attachment.model;
 	*bone = attachment.bone;
@@ -1010,24 +928,21 @@ OMP_CAPI(Player_GetAttachedObject, bool(objectPtr player, int index, int* modeli
 	*scaleZ = attachment.scale.z;
 	*materialcolor1 = attachment.colour1.ARGB();
 	*materialcolor2 = attachment.colour2.ARGB();
-	return true;
 }
 
-OMP_CAPI(Player_SetFacingAngle, bool(objectPtr player, float angle))
+OMP_CAPI(Player_SetFacingAngle, void(objectPtr player, float angle))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	Vector3 rotation = player_->getRotation().ToEuler();
 	rotation.z = angle;
 	player_->setRotation(rotation);
-	return true;
 }
 
-OMP_CAPI(Player_SetOtherColor, bool(objectPtr player, objectPtr other, uint32_t color))
+OMP_CAPI(Player_SetOtherColor, void(objectPtr player, objectPtr other, uint32_t color))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	ENTITY_CAST_RET(IPlayer, other, other_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	ENTITY_CAST(IPlayer, other, other_);
 	player_->setOtherColour(*other_, Colour::FromRGBA(color));
-	return true;
 }
 
 OMP_CAPI(Player_GetOtherColor, bool(objectPtr player, objectPtr other))
@@ -1039,91 +954,80 @@ OMP_CAPI(Player_GetOtherColor, bool(objectPtr player, objectPtr other))
 	return hasPlayerSpecificColor;
 }
 
-OMP_CAPI(Player_AllowTeleport, bool(objectPtr player, bool allow))
+OMP_CAPI(Player_AllowTeleport, void(objectPtr player, bool allow))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->allowTeleport(allow);
-	return true;
 }
 
 OMP_CAPI(Player_IsTeleportAllowed, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	bool allowed = bool(player_->isTeleportAllowed());
-	return allowed;
+	return player_->isTeleportAllowed();
 }
 
-OMP_CAPI(Player_DisableRemoteVehicleCollisions, bool(objectPtr player, bool disable))
+OMP_CAPI(Player_SetRemoteVehicleCollisions, void(objectPtr player, bool enable))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	player_->setRemoteVehicleCollisions(!disable);
-	return true;
+	POOL_ENTITY(players, IPlayer, player, player_);
+	player_->setRemoteVehicleCollisions(enable);
 }
 
-OMP_CAPI(Player_SelectTextDraw, bool(objectPtr player, uint32_t hoverColour))
+OMP_CAPI(Player_BeginTextDrawSelection, void(objectPtr player, uint32_t hoverColour))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerTextDrawData, data, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerTextDrawData, data);
 	data->beginSelection(Colour::FromRGBA(hoverColour));
-	return true;
 }
 
-OMP_CAPI(Player_CancelSelectTextDraw, bool(objectPtr player))
+OMP_CAPI(Player_EndTextDrawSelection, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerTextDrawData, data, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerTextDrawData, data);
 	data->endSelection();
-	return true;
 }
 
-OMP_CAPI(Player_SendClientCheck, bool(objectPtr player, int actionType, int address, int offset, int count))
+OMP_CAPI(Player_SendClientCheck, void(objectPtr player, int actionType, int address, int offset, int count))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->sendClientCheck(actionType, address, offset, count);
-	return true;
 }
 
-OMP_CAPI(Player_Spawn, bool(objectPtr player))
+OMP_CAPI(Player_Spawn, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->spawn();
-	return true;
 }
 
-OMP_CAPI(Player_GetSerial, bool(objectPtr player, OutputStringViewPtr serial))
+OMP_CAPI(Player_GetSerial, void(objectPtr player, OutputStringViewPtr serial))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	auto result = player_->getSerial();
 	SET_CAPI_STRING_VIEW(serial, result);
-	return true;
 }
 
-OMP_CAPI(Player_IsAdmin, bool(objectPtr player))
+OMP_CAPI(Player_HasConsoleAccess, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	PLAYER_DATA_RET(player_, IPlayerConsoleData, data, false);
-	bool access = data->hasConsoleAccess();
-	return access;
+	return data->hasConsoleAccess();
 }
 
-OMP_CAPI(Player_Kick, bool(objectPtr player))
+OMP_CAPI(Player_Kick, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->kick();
-	return true;
 }
 
-OMP_CAPI(Player_SendGameText, bool(objectPtr player, StringCharPtr text, int time, int style))
+OMP_CAPI(Player_SendGameText, void(objectPtr player, StringCharPtr text, int time, int style))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->sendGameText(text, Milliseconds(time), style);
 }
 
-OMP_CAPI(Player_HideGameText, bool(objectPtr player, int style))
+OMP_CAPI(Player_HideGameText, void(objectPtr player, int style))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->hideGameText(style);
-	return true;
 }
 
 OMP_CAPI(Player_HasGameText, bool(objectPtr player, int style))
@@ -1149,27 +1053,24 @@ OMP_CAPI(Player_GetGameText, bool(objectPtr player, int style, OutputStringViewP
 	return false;
 }
 
-OMP_CAPI(Player_Ban, bool(objectPtr player))
+OMP_CAPI(Player_Ban, void(objectPtr player))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->ban();
-	return true;
 }
 
-OMP_CAPI(Player_BanEx, bool(objectPtr player, StringCharPtr reason))
+OMP_CAPI(Player_BanEx, void(objectPtr player, StringCharPtr reason))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->ban(reason);
-	return true;
 }
 
-OMP_CAPI(Player_SendDeathMessage, bool(objectPtr player, objectPtr killee, objectPtr killer, int weapon))
+OMP_CAPI(Player_SendDeathMessage, void(objectPtr player, objectPtr killee, objectPtr killer, int weapon))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	ENTITY_CAST_RET(IPlayer, killee, killee_, false);
-	ENTITY_CAST_RET(IPlayer, killer, killer_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	ENTITY_CAST(IPlayer, killee, killee_);
+	ENTITY_CAST(IPlayer, killer, killer_);
 	player_->sendDeathMessage(*killee_, killer_, weapon);
-	return true;
 }
 
 OMP_CAPI(Player_SendEmptyDeathMessage, void(objectPtr player))
@@ -1178,12 +1079,11 @@ OMP_CAPI(Player_SendEmptyDeathMessage, void(objectPtr player))
 	player_->sendEmptyDeathMessage();
 }
 
-OMP_CAPI(Player_SendChatMessage, bool(objectPtr player, objectPtr sender, StringCharPtr message))
+OMP_CAPI(Player_SendChatMessage, void(objectPtr player, objectPtr sender, StringCharPtr message))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	ENTITY_CAST_RET(IPlayer, sender, sender_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	ENTITY_CAST(IPlayer, sender, sender_);
 	player_->sendChatMessage(*sender_, message);
-	return true;
 }
 
 OMP_CAPI(Player_GetClientVersion, int(objectPtr player))
@@ -1228,9 +1128,9 @@ OMP_CAPI(Player_GetSurfingOffsets, bool(objectPtr player, float* offsetX, float*
 	return true;
 }
 
-OMP_CAPI(Player_GetRotationQuat, bool(objectPtr player, float* x, float* y, float* z, float* w))
+OMP_CAPI(Player_GetRotationQuat, void(objectPtr player, float* x, float* y, float* z, float* w))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	glm::quat rotQuat = player_->getRotation().q;
 
 	// In samp or YSF, GetPlayerRotationQuat declaration is like this:
@@ -1242,21 +1142,15 @@ OMP_CAPI(Player_GetRotationQuat, bool(objectPtr player, float* x, float* y, floa
 	*y = rotQuat.x;
 	*z = rotQuat.y;
 	*w = rotQuat.z;
-	return true;
 }
 
-OMP_CAPI(Player_GetPlayerSpectateID, int(objectPtr player))
+OMP_CAPI(Player_GetSpectateData, void(objectPtr player, bool* spectating, int* spectateID, int* type))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	int spectateId = player_->getSpectateData().spectateID;
-	return spectateId;
-}
-
-OMP_CAPI(Player_GetSpectateType, int(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	int spectateType = int(player_->getSpectateData().type);
-	return spectateType;
+	POOL_ENTITY(players, IPlayer, player, player_);
+	auto data = player_->getSpectateData();
+	*spectating = data.spectating;
+	*spectateID = data.spectateID;
+	*type = data.type;
 }
 
 OMP_CAPI(Player_GetRawIp, uint32_t(objectPtr player))
@@ -1266,11 +1160,10 @@ OMP_CAPI(Player_GetRawIp, uint32_t(objectPtr player))
 	return ip;
 }
 
-OMP_CAPI(Player_SetGravity, bool(objectPtr player, float gravity))
+OMP_CAPI(Player_SetGravity, void(objectPtr player, float gravity))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->setGravity(gravity);
-	return true;
 }
 
 OMP_CAPI(Player_GetGravity, float(objectPtr player))
@@ -1280,12 +1173,11 @@ OMP_CAPI(Player_GetGravity, float(objectPtr player))
 	return gravity;
 }
 
-OMP_CAPI(Player_SetAdmin, bool(objectPtr player, bool set))
+OMP_CAPI(Player_SetConsoleAccessibility, void(objectPtr player, bool set))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_DATA_RET(player_, IPlayerConsoleData, data, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerConsoleData, data);
 	data->setConsoleAccessibility(set);
-	return true;
 }
 
 OMP_CAPI(Player_IsSpawned, bool(objectPtr player))
@@ -1316,32 +1208,29 @@ OMP_CAPI(Player_GetControllable, bool(objectPtr player))
 	return controllable;
 }
 
-OMP_CAPI(Player_IsCameraTargetEnabled, bool(objectPtr player))
+OMP_CAPI(Player_HasCameraTargetting, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	bool enabled = bool(player_->hasCameraTargeting());
 	return enabled;
 }
 
-OMP_CAPI(Player_ToggleGhostMode, bool(objectPtr player, bool toggle))
+OMP_CAPI(Player_ToggleGhostMode, void(objectPtr player, bool toggle))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->toggleGhostMode(toggle);
-	return true;
 }
 
-OMP_CAPI(Player_GetGhostMode, bool(objectPtr player))
+OMP_CAPI(Player_IsGhostModeEnabled, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	bool enabled = bool(player_->isGhostModeEnabled());
-	return enabled;
+	return player_->isGhostModeEnabled();
 }
 
-OMP_CAPI(Player_AllowWeapons, bool(objectPtr player, bool allow))
+OMP_CAPI(Player_AllowWeapons, void(objectPtr player, bool allow))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	player_->allowWeapons(allow);
-	return true;
 }
 
 OMP_CAPI(Player_AreWeaponsAllowed, bool(objectPtr player))
@@ -1354,16 +1243,14 @@ OMP_CAPI(Player_AreWeaponsAllowed, bool(objectPtr player))
 OMP_CAPI(Player_IsPlayerUsingOfficialClient, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	bool ret = bool(player_->isUsingOfficialClient());
-	return ret;
+	return player_->isUsingOfficialClient();
 }
 
 OMP_CAPI(Player_IsInDriveByMode, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	PLAYER_DATA_RET(player_, IPlayerVehicleData, data, false);
-	bool driveby = bool(data->isInDriveByMode());
-	return driveby;
+	return data->isInDriveByMode();
 }
 
 OMP_CAPI(Player_IsCuffed, bool(objectPtr player))
@@ -1383,4 +1270,86 @@ OMP_CAPI(Player_IsCuffed, bool(objectPtr player))
 		}
 	}
 	return cuffed;
+}
+
+OMP_CAPI(Player_GetCustomSkin, uint32_t(objectPtr player))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	PLAYER_DATA_RET(player_, IPlayerCustomModelsData, data, 0);
+	return data->getCustomSkin();
+}
+
+OMP_CAPI(Player_GetMenu, objectPtr(objectPtr player))
+{
+	IMenusComponent* component = ComponentManager::Get()->menus;
+	if (component)
+	{
+		POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
+		IPlayerMenuData* menuData = queryExtension<IPlayerMenuData>(player_);
+		if (menuData)
+		{
+			return component->get(menuData->getMenuID());
+		}
+	}
+	return nullptr;
+}
+
+OMP_CAPI(Player_BeginEditingObject, void(objectPtr player, objectPtr object))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
+	POOL_ENTITY(objects, IObject, object, object_);
+	data->beginEditing(*object_);
+}
+
+OMP_CAPI(Player_BeginEditingPlayerObject, void(objectPtr player, objectPtr object))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
+	PLAYER_POOL_ENTITY(player_, IPlayerObjectData, IPlayerObject, object, object_);
+	data->beginEditing(*object_);
+}
+
+OMP_CAPI(Player_BeginSelectingObject, void(objectPtr player))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
+	data->beginSelecting();
+}
+
+OMP_CAPI(Player_EndEditingObject, void(objectPtr player))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_DATA(player_, IPlayerObjectData, data);
+	data->endEditing();
+}
+
+OMP_CAPI(Player_RedirectDownload, bool(objectPtr player, StringCharPtr url))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	PLAYER_DATA_RET(player_, IPlayerCustomModelsData, data, false);
+
+	if (!data->sendDownloadUrl(url))
+	{
+		ComponentManager::Get()->core->logLn(LogLevel::Warning, "This function can be used only within OnPlayerRequestDownload event.");
+		return false;
+	}
+	return true;
+}
+
+OMP_CAPI(Player_GetCheckpoint, objectPtr(objectPtr player))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
+	PLAYER_DATA_RET(player_, IPlayerCheckpointData, data, nullptr);
+	const ICheckpointData& cp = data->getCheckpoint();
+	return &cp;
+}
+
+OMP_CAPI(Player_GetRaceCheckpoint, objectPtr(objectPtr player))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
+	PLAYER_DATA_RET(player_, IPlayerCheckpointData, data, nullptr);
+	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player_);
+	const IRaceCheckpointData& cp = playerData->getRaceCheckpoint();
+	return &cp;
 }

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -107,6 +107,15 @@ OMP_CAPI(Player_SetCameraLookAt, bool(objectPtr player, float x, float y, float 
 	return true;
 }
 
+OMP_CAPI(Player_GetCameraLookAt, void(objectPtr player, float* x, float* y, float* z))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	auto pos = player_->getCameraLookAt();
+	*x = pos.x;
+	*y = pos.y;
+	*z = pos.z;
+}
+
 OMP_CAPI(Player_SetCameraBehind, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1370,14 +1370,6 @@ OMP_CAPI(Player_IsPlayerUsingOfficialClient, bool(objectPtr player))
 	return ret;
 }
 
-OMP_CAPI(Player_GetAnimationFlags, int(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	PlayerAnimationData data = player_->getAnimationData();
-	int flags = data.flags;
-	return flags;
-}
-
 OMP_CAPI(Player_IsInDriveByMode, bool(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -405,6 +405,24 @@ OMP_CAPI(Player_GetVelocity, bool(objectPtr player, float* x, float* y, float* z
 	return true;
 }
 
+OMP_CAPI(Player_GetAimData, bool(objectPtr player, float* frontVectorX, float* frontVectorY, float* frontVectorZ, float* posX, float* posY, float* posZ, float* aimZ, float* camZoom, float* aspectRatio, int8_t* weaponState, uiint8_t* camMode))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	auto data = player_->getAimData();
+	*frontVectorX = data.camFrontVector.x;
+	*frontVectorY = data.camFrontVector.y;
+	*frontVectorZ = data.camFrontVector.z;
+	*posX = data.camPos.x;
+	*posY = data.camPos.y;
+	*posZ = data.camPos.z;
+	*aimZ = data.aimZ;
+	*camZoom = data.camZoom;
+	*aspectRatio = data.aspectRatio;
+	*weaponState = data.weaponState;
+	*camMode = data.camMode;
+	return true;
+}
+
 OMP_CAPI(Player_GetCameraPos, bool(objectPtr player, float* x, float* y, float* z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -383,7 +383,7 @@ OMP_CAPI(Player_ForceClassSelection, bool(objectPtr player))
 	return true;
 }
 
-OMP_CAPI(Player_GetWantedLevel, int(objectPtr player))
+OMP_CAPI(Player_GetWantedLevel, unsigned(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	auto wanted = player_->getWantedLevel();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -561,7 +561,7 @@ OMP_CAPI(Player_GetWorldBounds, bool(objectPtr player, float* xmax, float* xmin,
 	return true;
 }
 
-OMP_CAPI(Player_ClearAnimations, bool(objectPtr player, int syncType))
+OMP_CAPI(Player_ClearTasks, bool(objectPtr player, int syncType))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->clearTasks(PlayerAnimationSyncType(syncType));

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1177,6 +1177,12 @@ OMP_CAPI(Player_SendDeathMessage, bool(objectPtr player, objectPtr killee, objec
 	return true;
 }
 
+OMP_CAPI(Player_SendEmptyDeathMessage, void(objectPtr player))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	player_->sendEmptyDeathMessage();
+}
+
 OMP_CAPI(Player_SendMessageToPlayer, bool(objectPtr player, objectPtr sender, StringCharPtr message))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -1084,11 +1084,11 @@ OMP_CAPI(Player_Spawn, bool(objectPtr player))
 	return true;
 }
 
-OMP_CAPI(Player_GetSerial, bool(objectPtr player, OutputStringViewPtr gpci))
+OMP_CAPI(Player_GetSerial, bool(objectPtr player, OutputStringViewPtr serial))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	auto result = player_->getSerial();
-	SET_CAPI_STRING_VIEW(gpci, result);
+	SET_CAPI_STRING_VIEW(serial, result);
 	return true;
 }
 

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -827,7 +827,7 @@ OMP_CAPI(Player_GetWeaponSlot, bool(objectPtr player, int slot, uint8_t* weapon,
 	}
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	const WeaponSlotData& weapon = player_->getWeaponSlot(slot);
-	*weaponid = weapon.id;
+	*weapon = weapon.id;
 	*ammo = weapon.ammo;
 	return true;
 }

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -143,7 +143,7 @@ OMP_CAPI(All_CreateExplosion, bool(float x, float y, float z, int type, float ra
 	return true;
 }
 
-OMP_CAPI(Player_PlayAudioStream, bool(objectPtr player, StringCharPtr url, float x, float y, float z, float distance, bool usePos))
+OMP_CAPI(Player_PlayAudio, bool(objectPtr player, StringCharPtr url, float x, float y, float z, float distance, bool usePos))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->playAudio(url, usePos, { x, y, z }, distance);

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -332,7 +332,7 @@ OMP_CAPI(Player_GetPing, int(objectPtr player))
 	return ping;
 }
 
-OMP_CAPI(Player_GetWeapon, int(objectPtr player))
+OMP_CAPI(Player_GetArmedWeapon, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	int weapon = player_->getArmedWeapon();

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -502,7 +502,7 @@ OMP_CAPI(Player_PlaySound, bool(objectPtr player, uint32_t sound, float x, float
 
 OMP_CAPI(Player_LastPlayedSound, uint32_t(objectPtr player))
 {
-	POOL_ENTITY(players, IPlayer, player, player_);
+	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	return player_->lastPlayedSound();
 }
 

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -493,7 +493,7 @@ OMP_CAPI(Player_IsStreamedIn, bool(objectPtr player, objectPtr other))
 	return streamed;
 }
 
-OMP_CAPI(Player_PlayGameSound, bool(objectPtr player, uint32_t sound, float x, float y, float z))
+OMP_CAPI(Player_PlaySound, bool(objectPtr player, uint32_t sound, float x, float y, float z))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	player_->playSound(sound, { x, y, z });

--- a/src/Impl/Players/APIs.cpp
+++ b/src/Impl/Players/APIs.cpp
@@ -823,13 +823,6 @@ OMP_CAPI(Player_GetWeaponData, bool(objectPtr player, int slot, int* weaponid, i
 	return true;
 }
 
-OMP_CAPI(Player_GetWeaponState, int(objectPtr player))
-{
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	int state = player_->getAimData().weaponState;
-	return state;
-}
-
 OMP_CAPI(Player_InterpolateCameraPos, bool(objectPtr player, float from_x, float from_y, float from_z, float to_x, float to_y, float to_z, int time, int cut))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -256,6 +256,14 @@ OMP_CAPI(PlayerTextLabel_AttachToPlayer, void(objectPtr player, objectPtr textla
 	textlabel_->attachToPlayer(*target_, { offsetX, offsetY, offsetZ });
 }
 
+OMP_CAPI(PlayerTextLabel_DetachFromPlayer, void(objectPtr player, objectPtr textlabel, float offsetX, float offsetY, float offsetZ))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
+
+	textlabel_->detachFromPlayer({ offsetX, offsetY, offsetZ });
+}
+
 OMP_CAPI(PlayerTextLabel_UpdateText, void(objectPtr player, objectPtr textlabel, uint32_t color, StringCharPtr text))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -186,7 +186,7 @@ OMP_CAPI(TextLabel_GetAttachmentData, void(objectPtr textlabel, int* attached_pl
 	Per-Player TextLabel
 */
 
-OMP_CAPI(PlayerTextLabel_Create, objectPtr(objectPtr player, StringCharPtr text, uint32_t color, float x, float y, float z, float drawDistance, objectPtr attachedPlayer, objectPtr attachedVehicle, bool los, int* id))
+OMP_CAPI(PlayerTextLabel_Create, objectPtr(objectPtr player, StringCharPtr text, uint32_t color, float x, float y, float z, float drawDistance, objectPtr attachedPlayer, objectPtr attachedVehicle, bool los))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
 	IPlayerTextLabelData* labelData = queryExtension<IPlayerTextLabelData>(player_);
@@ -209,7 +209,6 @@ OMP_CAPI(PlayerTextLabel_Create, objectPtr(objectPtr player, StringCharPtr text,
 
 		if (textlabel)
 		{
-			*id = textlabel->getID();
 			return textlabel;
 		}
 	}

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -73,7 +73,7 @@ OMP_CAPI(TextLabel_IsValid, bool(objectPtr textlabel))
 	return true;
 }
 
-OMP_CAPI(TextLabel_IsStreamedIn, bool(objectPtr textlabel, objectPtr player))
+OMP_CAPI(TextLabel_IsStreamedInForPlayer, bool(objectPtr textlabel, objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -100,7 +100,7 @@ OMP_CAPI(TextLabel_SetPosition, void(objectPtr textlabel, float x, float y, floa
 	textlabel_->setPosition({ x, y, z });
 }
 
-OMP_CAPI(TextLabel_GetPos, void(objectPtr textlabel, float* x, float* y, float* z))
+OMP_CAPI(TextLabel_GetPosition, void(objectPtr textlabel, float* x, float* y, float* z))
 {
 	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	const Vector3& pos = textlabel_->getPosition();

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -94,6 +94,12 @@ OMP_CAPI(TextLabel_GetColor, uint32_t(objectPtr textlabel))
 	return textlabel_->getColour().RGBA();
 }
 
+OMP_CAPI(TextLabel_SetPosition, void(objectPtr textlabel, float x, float y, float z))
+{
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
+	textlabel_->setPosition({ x, y, z });
+}
+
 OMP_CAPI(TextLabel_GetPos, void(objectPtr textlabel, float* x, float* y, float* z))
 {
 	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -376,6 +376,13 @@ OMP_CAPI(PlayerTextLabel_SetLOS, void(objectPtr player, objectPtr textlabel, boo
 	textlabel_->setTestLOS(status);
 }
 
+OMP_CAPI(PlayerTextLabel_SetVirtualWorld, void(objectPtr player, objectPtr textlabel, int world))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
+	textlabel_->setVirtualWorld(world);
+}
+
 OMP_CAPI(PlayerTextLabel_GetVirtualWorld, int(objectPtr player, objectPtr textlabel))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -246,6 +246,16 @@ OMP_CAPI(PlayerTextLabel_GetID, int(objectPtr player, objectPtr textlabel))
 	return textlabel_->getID();
 }
 
+OMP_CAPI(PlayerTextLabel_AttachToPlayer, void(objectPtr player, objectPtr textlabel, objectPtr target, float offsetX, float offsetY, float offsetZ))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
+
+	ENTITY_CAST(IPlayer, target, target_);
+
+	textlabel_->attachToPlayer(*target_, { offsetX, offsetY, offsetZ });
+}
+
 OMP_CAPI(PlayerTextLabel_UpdateText, void(objectPtr player, objectPtr textlabel, uint32_t color, StringCharPtr text))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -264,6 +264,16 @@ OMP_CAPI(PlayerTextLabel_DetachFromPlayer, void(objectPtr player, objectPtr text
 	textlabel_->detachFromPlayer({ offsetX, offsetY, offsetZ });
 }
 
+OMP_CAPI(PlayerTextLabel_AttachToVehicle, void(objectPtr player, objectPtr textlabel, objectPtr target, float offsetX, float offsetY, float offsetZ))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
+
+	ENTITY_CAST(IVehicle, target, target_);
+
+	textlabel_->attachToVehicle(*target_, { offsetX, offsetY, offsetZ });
+}
+
 OMP_CAPI(PlayerTextLabel_UpdateText, void(objectPtr player, objectPtr textlabel, uint32_t color, StringCharPtr text))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -262,6 +262,13 @@ OMP_CAPI(PlayerTextLabel_IsValid, bool(objectPtr player, objectPtr textlabel, bo
 	return true;
 }
 
+OMP_CAPI(PlayerTextLabel_SetText, void(objectPtr player, objectPtr textlabel, StringCharPtr text))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
+	textlabel_->setText(text);
+}
+
 OMP_CAPI(PlayerTextLabel_GetText, void(objectPtr player, objectPtr textlabel, OutputStringViewPtr output))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -289,7 +289,7 @@ OMP_CAPI(PlayerTextLabel_UpdateText, void(objectPtr player, objectPtr textlabel,
 	textlabel_->setColourAndText(Colour::FromRGBA(color), text);
 }
 
-OMP_CAPI(PlayerTextLabel_IsValid, bool(objectPtr player, objectPtr textlabel, bool* valid))
+OMP_CAPI(PlayerTextLabel_IsValid, bool(objectPtr player, objectPtr textlabel))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -23,11 +23,10 @@ OMP_CAPI(TextLabel_Create, objectPtr(StringCharPtr text, uint32_t color, float x
 	return nullptr;
 }
 
-OMP_CAPI(TextLabel_Destroy, bool(objectPtr textlabel))
+OMP_CAPI(TextLabel_Destroy, void(objectPtr textlabel))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	ComponentManager::Get()->textlabels->release(textlabel_->getID());
-	return true;
 }
 
 OMP_CAPI(TextLabel_FromID, objectPtr(int textlabelid))
@@ -46,27 +45,24 @@ OMP_CAPI(TextLabel_GetID, int(objectPtr textlabel))
 	return textlabel_->getID();
 }
 
-OMP_CAPI(TextLabel_AttachToPlayer, bool(objectPtr textlabel, objectPtr player, float offsetX, float offsetY, float offsetZ))
+OMP_CAPI(TextLabel_AttachToPlayer, void(objectPtr textlabel, objectPtr player, float offsetX, float offsetY, float offsetZ))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
+	POOL_ENTITY(players, IPlayer, player, player_);
 	textlabel_->attachToPlayer(*player_, { offsetX, offsetY, offsetZ });
-	return true;
 }
 
-OMP_CAPI(TextLabel_AttachToVehicle, bool(objectPtr textlabel, objectPtr vehicle, float offsetX, float offsetY, float offsetZ))
+OMP_CAPI(TextLabel_AttachToVehicle, void(objectPtr textlabel, objectPtr vehicle, float offsetX, float offsetY, float offsetZ))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
-	POOL_ENTITY_RET(vehicles, IVehicle, vehicle, vehicle_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
+	POOL_ENTITY(vehicles, IVehicle, vehicle, vehicle_);
 	textlabel_->attachToVehicle(*vehicle_, { offsetX, offsetY, offsetZ });
-	return true;
 }
 
-OMP_CAPI(TextLabel_UpdateText, bool(objectPtr textlabel, uint32_t color, StringCharPtr text))
+OMP_CAPI(TextLabel_UpdateText, void(objectPtr textlabel, uint32_t color, StringCharPtr text))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	textlabel_->setColourAndText(Colour::FromRGBA(color), text);
-	return true;
 }
 
 OMP_CAPI(TextLabel_IsValid, bool(objectPtr textlabel))
@@ -85,12 +81,11 @@ OMP_CAPI(TextLabel_IsStreamedIn, bool(objectPtr player, objectPtr textlabel))
 	return streamed;
 }
 
-OMP_CAPI(TextLabel_GetText, bool(objectPtr textlabel, OutputStringViewPtr output))
+OMP_CAPI(TextLabel_GetText, void(objectPtr textlabel, OutputStringViewPtr output))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	auto result = textlabel_->getText();
 	SET_CAPI_STRING_VIEW(output, result);
-	return true;
 }
 
 OMP_CAPI(TextLabel_GetColor, uint32_t(objectPtr textlabel))
@@ -99,22 +94,20 @@ OMP_CAPI(TextLabel_GetColor, uint32_t(objectPtr textlabel))
 	return textlabel_->getColour().RGBA();
 }
 
-OMP_CAPI(TextLabel_GetPos, bool(objectPtr textlabel, float* x, float* y, float* z))
+OMP_CAPI(TextLabel_GetPos, void(objectPtr textlabel, float* x, float* y, float* z))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	const Vector3& pos = textlabel_->getPosition();
 
 	*x = pos.x;
 	*y = pos.y;
 	*z = pos.z;
-	return true;
 }
 
-OMP_CAPI(TextLabel_SetDrawDistance, bool(objectPtr textlabel, float distance))
+OMP_CAPI(TextLabel_SetDrawDistance, void(objectPtr textlabel, float distance))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	textlabel_->setDrawDistance(distance);
-	return true;
 }
 
 OMP_CAPI(TextLabel_GetDrawDistance, float(objectPtr textlabel))
@@ -131,11 +124,10 @@ OMP_CAPI(TextLabel_GetLOS, bool(objectPtr textlabel))
 	return los;
 }
 
-OMP_CAPI(TextLabel_SetLOS, bool(objectPtr textlabel, bool status))
+OMP_CAPI(TextLabel_SetLOS, void(objectPtr textlabel, bool status))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	textlabel_->setTestLOS(status);
-	return true;
 }
 
 OMP_CAPI(TextLabel_GetVirtualWorld, int(objectPtr textlabel))
@@ -145,22 +137,19 @@ OMP_CAPI(TextLabel_GetVirtualWorld, int(objectPtr textlabel))
 	return virtualWorld;
 }
 
-OMP_CAPI(TextLabel_SetVirtualWorld, bool(objectPtr textlabel, int world))
+OMP_CAPI(TextLabel_SetVirtualWorld, void(objectPtr textlabel, int world))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	textlabel_->setVirtualWorld(world);
-	return true;
 }
 
-OMP_CAPI(TextLabel_GetAttachedData, bool(objectPtr textlabel, int* attached_player, int* attached_vehicle))
+OMP_CAPI(TextLabel_GetAttachedData, void(objectPtr textlabel, int* attached_player, int* attached_vehicle))
 {
-	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	const TextLabelAttachmentData& data = textlabel_->getAttachmentData();
 
 	*attached_player = data.playerID;
 	*attached_vehicle = data.vehicleID;
-
-	return true;
 }
 
 /*
@@ -197,17 +186,17 @@ OMP_CAPI(PlayerTextLabel_Create, objectPtr(objectPtr player, StringCharPtr text,
 	return nullptr;
 }
 
-OMP_CAPI(PlayerTextLabel_Destroy, bool(objectPtr player, objectPtr textlabel))
+OMP_CAPI(PlayerTextLabel_Destroy, void(objectPtr player, objectPtr textlabel))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	auto data = queryExtension<IPlayerTextLabelData>(player_);
 	if (!data)
 	{
-		return false;
+		return;
 	}
 	data->release(textlabel_->getID());
-	return true;
+	return;
 }
 
 OMP_CAPI(PlayerTextLabel_FromID, objectPtr(objectPtr player, int textlabelid))
@@ -228,12 +217,11 @@ OMP_CAPI(PlayerTextLabel_GetID, int(objectPtr player, objectPtr textlabel))
 	return textlabel_->getID();
 }
 
-OMP_CAPI(PlayerTextLabel_UpdateText, bool(objectPtr player, objectPtr textlabel, uint32_t color, StringCharPtr text))
+OMP_CAPI(PlayerTextLabel_UpdateText, void(objectPtr player, objectPtr textlabel, uint32_t color, StringCharPtr text))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	textlabel_->setColourAndText(Colour::FromRGBA(color), text);
-	return true;
 }
 
 OMP_CAPI(PlayerTextLabel_IsValid, bool(objectPtr player, objectPtr textlabel, bool* valid))
@@ -245,13 +233,12 @@ OMP_CAPI(PlayerTextLabel_IsValid, bool(objectPtr player, objectPtr textlabel, bo
 	return true;
 }
 
-OMP_CAPI(PlayerTextLabel_GetText, bool(objectPtr player, objectPtr textlabel, OutputStringViewPtr output))
+OMP_CAPI(PlayerTextLabel_GetText, void(objectPtr player, objectPtr textlabel, OutputStringViewPtr output))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	auto result = textlabel_->getText();
 	SET_CAPI_STRING_VIEW(output, result);
-	return true;
 }
 
 OMP_CAPI(PlayerTextLabel_GetColor, bool(objectPtr player, objectPtr textlabel, uint32_t* color))
@@ -262,24 +249,22 @@ OMP_CAPI(PlayerTextLabel_GetColor, bool(objectPtr player, objectPtr textlabel, u
 	return true;
 }
 
-OMP_CAPI(PlayerTextLabel_GetPos, bool(objectPtr player, objectPtr textlabel, float* x, float* y, float* z))
+OMP_CAPI(PlayerTextLabel_GetPos, void(objectPtr player, objectPtr textlabel, float* x, float* y, float* z))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	const Vector3& pos = textlabel_->getPosition();
 
 	*x = pos.x;
 	*y = pos.y;
 	*z = pos.z;
-	return true;
 }
 
-OMP_CAPI(PlayerTextLabel_SetDrawDistance, bool(objectPtr player, objectPtr textlabel, float distance))
+OMP_CAPI(PlayerTextLabel_SetDrawDistance, void(objectPtr player, objectPtr textlabel, float distance))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	textlabel_->setDrawDistance(distance);
-	return true;
 }
 
 OMP_CAPI(PlayerTextLabel_GetDrawDistance, float(objectPtr player, objectPtr textlabel))
@@ -298,12 +283,11 @@ OMP_CAPI(PlayerTextLabel_GetLOS, bool(objectPtr player, objectPtr textlabel))
 	return los;
 }
 
-OMP_CAPI(PlayerTextLabel_SetLOS, bool(objectPtr player, objectPtr textlabel, bool status))
+OMP_CAPI(PlayerTextLabel_SetLOS, void(objectPtr player, objectPtr textlabel, bool status))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	textlabel_->setTestLOS(status);
-	return true;
 }
 
 OMP_CAPI(PlayerTextLabel_GetVirtualWorld, int(objectPtr player))
@@ -312,14 +296,12 @@ OMP_CAPI(PlayerTextLabel_GetVirtualWorld, int(objectPtr player))
 	return player_->getVirtualWorld();
 }
 
-OMP_CAPI(PlayerTextLabel_GetAttachedData, bool(objectPtr player, objectPtr textlabel, int* attached_player, int* attached_vehicle))
+OMP_CAPI(PlayerTextLabel_GetAttachedData, void(objectPtr player, objectPtr textlabel, int* attached_player, int* attached_vehicle))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	const TextLabelAttachmentData& data = textlabel_->getAttachmentData();
 
 	*attached_player = data.playerID;
 	*attached_vehicle = data.vehicleID;
-
-	return true;
 }

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -279,8 +279,8 @@ OMP_CAPI(PlayerTextLabel_GetText, void(objectPtr player, objectPtr textlabel, Ou
 
 OMP_CAPI(PlayerTextLabel_SetColor, void(objectPtr player, objectPtr textlabel, uint32_t color))
 {
-	POOL_ENTITY(players, IPlayer, player, player_, 0);
-	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, 0);
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
 	textlabel_->setColour(Colour::FromRGBA(color));
 }
 

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -94,6 +94,12 @@ OMP_CAPI(TextLabel_GetText, void(objectPtr textlabel, OutputStringViewPtr output
 	SET_CAPI_STRING_VIEW(output, result);
 }
 
+OMP_CAPI(TextLabel_SetColor, void(objectPtr textlabel, uint32_t color))
+{
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
+	textlabel_->setColour(Colour::FromRGBA(color));
+}
+
 OMP_CAPI(TextLabel_GetColor, uint32_t(objectPtr textlabel))
 {
 	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, 0);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -279,8 +279,8 @@ OMP_CAPI(PlayerTextLabel_GetText, void(objectPtr player, objectPtr textlabel, Ou
 
 OMP_CAPI(PlayerTextLabel_SetColor, void(objectPtr player, objectPtr textlabel, uint32_t color))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, 0);
+	POOL_ENTITY(players, IPlayer, player, player_, 0);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, 0);
 	textlabel_->setColour(Colour::FromRGBA(color));
 }
 

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -186,7 +186,7 @@ OMP_CAPI(TextLabel_GetAttachmentData, void(objectPtr textlabel, int* attached_pl
 	Per-Player TextLabel
 */
 
-OMP_CAPI(PlayerTextLabel_Create, objectPtr(objectPtr player, StringCharPtr text, uint32_t color, float x, float y, float z, float drawDistance, objectPtr attachedPlayer, objectPtr attachedVehicle, bool los))
+OMP_CAPI(PlayerTextLabel_Create, objectPtr(objectPtr player, StringCharPtr text, uint32_t color, float x, float y, float z, float drawDistance, bool los, objectPtr attachedPlayer, objectPtr attachedVehicle))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
 	IPlayerTextLabelData* labelData = queryExtension<IPlayerTextLabelData>(player_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -241,12 +241,11 @@ OMP_CAPI(PlayerTextLabel_GetText, void(objectPtr player, objectPtr textlabel, Ou
 	SET_CAPI_STRING_VIEW(output, result);
 }
 
-OMP_CAPI(PlayerTextLabel_GetColor, bool(objectPtr player, objectPtr textlabel, uint32_t* color))
+OMP_CAPI(PlayerTextLabel_GetColor, uint32_t(objectPtr player, objectPtr textlabel))
 {
-	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
-	*color = textlabel_->getColour().RGBA();
-	return true;
+	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, 0);
+	return textlabel_->getColour().RGBA();
 }
 
 OMP_CAPI(PlayerTextLabel_GetPos, void(objectPtr player, objectPtr textlabel, float* x, float* y, float* z))

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -81,6 +81,12 @@ OMP_CAPI(TextLabel_IsStreamedInForPlayer, bool(objectPtr textlabel, objectPtr pl
 	return streamed;
 }
 
+OMP_CAPI(TextLabel_SetText, void(objectPtr textlabel, StringCharPtr text))
+{
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
+	textlabel_->setText(text);
+}
+
 OMP_CAPI(TextLabel_GetText, void(objectPtr textlabel, OutputStringViewPtr output))
 {
 	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -327,6 +327,14 @@ OMP_CAPI(PlayerTextLabel_GetColor, uint32_t(objectPtr player, objectPtr textlabe
 	return textlabel_->getColour().RGBA();
 }
 
+OMP_CAPI(PlayerTextLabel_SetPosition, void(objectPtr player, objectPtr textlabel, float x, float y, float z))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
+
+	textlabel_->setPosition({ x, y, z });
+}
+
 OMP_CAPI(PlayerTextLabel_GetPosition, void(objectPtr player, objectPtr textlabel, float* x, float* y, float* z))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -318,7 +318,7 @@ OMP_CAPI(PlayerTextLabel_SetLOS, void(objectPtr player, objectPtr textlabel, boo
 	textlabel_->setTestLOS(status);
 }
 
-OMP_CAPI(PlayerTextLabel_GetVirtualWorld, int(objectPtr player))
+OMP_CAPI(PlayerTextLabel_GetVirtualWorld, int(objectPtr player, objectPtr textlabel))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
 	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -327,7 +327,7 @@ OMP_CAPI(PlayerTextLabel_GetColor, uint32_t(objectPtr player, objectPtr textlabe
 	return textlabel_->getColour().RGBA();
 }
 
-OMP_CAPI(PlayerTextLabel_GetPos, void(objectPtr player, objectPtr textlabel, float* x, float* y, float* z))
+OMP_CAPI(PlayerTextLabel_GetPosition, void(objectPtr player, objectPtr textlabel, float* x, float* y, float* z))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);
 	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -65,6 +65,12 @@ OMP_CAPI(TextLabel_AttachToVehicle, void(objectPtr textlabel, objectPtr vehicle,
 	textlabel_->attachToVehicle(*vehicle_, { offsetX, offsetY, offsetZ });
 }
 
+OMP_CAPI(TextLabel_DetachFromVehicle, void(objectPtr textlabel, float offsetX, float offsetY, float offsetZ))
+{
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
+	textlabel_->detachFromVehicle({ offsetX, offsetY, offsetZ });
+}
+
 OMP_CAPI(TextLabel_UpdateText, void(objectPtr textlabel, uint32_t color, StringCharPtr text))
 {
 	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -321,7 +321,8 @@ OMP_CAPI(PlayerTextLabel_SetLOS, void(objectPtr player, objectPtr textlabel, boo
 OMP_CAPI(PlayerTextLabel_GetVirtualWorld, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
-	return player_->getVirtualWorld();
+	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, false);
+	return textlabel_->getVirtualWorld();
 }
 
 OMP_CAPI(PlayerTextLabel_GetAttachedData, void(objectPtr player, objectPtr textlabel, int* attached_player, int* attached_vehicle))

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -73,7 +73,7 @@ OMP_CAPI(TextLabel_IsValid, bool(objectPtr textlabel))
 	return true;
 }
 
-OMP_CAPI(TextLabel_IsStreamedIn, bool(objectPtr player, objectPtr textlabel))
+OMP_CAPI(TextLabel_IsStreamedIn, bool(objectPtr textlabel, objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
 	POOL_ENTITY_RET(textlabels, ITextLabel, textlabel, textlabel_, false);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -274,6 +274,14 @@ OMP_CAPI(PlayerTextLabel_AttachToVehicle, void(objectPtr player, objectPtr textl
 	textlabel_->attachToVehicle(*target_, { offsetX, offsetY, offsetZ });
 }
 
+OMP_CAPI(PlayerTextLabel_DetachFromVehicle, void(objectPtr player, objectPtr textlabel, float offsetX, float offsetY, float offsetZ))
+{
+	POOL_ENTITY(players, IPlayer, player, player_);
+	PLAYER_POOL_ENTITY(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_);
+
+	textlabel_->detachFromVehicle({ offsetX, offsetY, offsetZ });
+}
+
 OMP_CAPI(PlayerTextLabel_UpdateText, void(objectPtr player, objectPtr textlabel, uint32_t color, StringCharPtr text))
 {
 	POOL_ENTITY(players, IPlayer, player, player_);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -277,6 +277,13 @@ OMP_CAPI(PlayerTextLabel_GetText, void(objectPtr player, objectPtr textlabel, Ou
 	SET_CAPI_STRING_VIEW(output, result);
 }
 
+OMP_CAPI(PlayerTextLabel_SetColor, void(objectPtr player, objectPtr textlabel, uint32_t color))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);
+	PLAYER_POOL_ENTITY_RET(player_, IPlayerTextLabelData, IPlayerTextLabel, textlabel, textlabel_, 0);
+	textlabel_->setColour(Colour::FromRGBA(color));
+}
+
 OMP_CAPI(PlayerTextLabel_GetColor, uint32_t(objectPtr player, objectPtr textlabel))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, 0);

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -173,7 +173,7 @@ OMP_CAPI(TextLabel_SetVirtualWorld, void(objectPtr textlabel, int world))
 	textlabel_->setVirtualWorld(world);
 }
 
-OMP_CAPI(TextLabel_GetAttachedData, void(objectPtr textlabel, int* attached_player, int* attached_vehicle))
+OMP_CAPI(TextLabel_GetAttachmentData, void(objectPtr textlabel, int* attached_player, int* attached_vehicle))
 {
 	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
 	const TextLabelAttachmentData& data = textlabel_->getAttachmentData();

--- a/src/Impl/TextLabels/APIs.cpp
+++ b/src/Impl/TextLabels/APIs.cpp
@@ -52,6 +52,12 @@ OMP_CAPI(TextLabel_AttachToPlayer, void(objectPtr textlabel, objectPtr player, f
 	textlabel_->attachToPlayer(*player_, { offsetX, offsetY, offsetZ });
 }
 
+OMP_CAPI(TextLabel_DetachFromPlayer, void(objectPtr textlabel, float offsetX, float offsetY, float offsetZ))
+{
+	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);
+	textlabel_->detachFromPlayer({ offsetX, offsetY, offsetZ });
+}
+
 OMP_CAPI(TextLabel_AttachToVehicle, void(objectPtr textlabel, objectPtr vehicle, float offsetX, float offsetY, float offsetZ))
 {
 	POOL_ENTITY(textlabels, ITextLabel, textlabel, textlabel_);

--- a/tools/generate_docs.js
+++ b/tools/generate_docs.js
@@ -17,7 +17,7 @@ const convertTypeNames = (type) => {
   } else if (type === "voidPtr") {
     return "void*";
   } else if (type === "OutputStringViewPtr") {
-    return "CAPIStringView*";
+    return "struct CAPIStringView*";
   } else {
     return type;
   }

--- a/tools/generate_single_header.js
+++ b/tools/generate_single_header.js
@@ -271,7 +271,7 @@ ${event.args.map((param) => `        ${convertEventArgTypeNames(param.type)}* ${
 };
 typedef bool (*EventCallback_${event.name})(struct EventArgs_${
           event.name
-        } args);\n`
+        }* args);\n`
       );
     });
   });

--- a/tools/generate_single_header.js
+++ b/tools/generate_single_header.js
@@ -144,7 +144,7 @@ files.forEach(async (file, index) => {
       const v0 = line.replace("OMP_CAPI(", "");
       const name_full = v0.split(", ")[0];
       const group = name_full.split("_")[0];
-      const name = name_full.split("_")[1];
+      const name = name_full.split("_").slice(1).join("_");
 
       if (APIs[group] === undefined) {
         APIs[group] = [];

--- a/tools/generate_single_header.js
+++ b/tools/generate_single_header.js
@@ -271,7 +271,7 @@ ${event.args.map((param) => `        ${convertEventArgTypeNames(param.type)}* ${
 };
 typedef bool (*EventCallback_${event.name})(struct EventArgs_${
           event.name
-        }* args);\n`
+        } args);\n`
       );
     });
   });


### PR DESCRIPTION
### Proposals
- In macro functions, for example, POOL_ENTITY why do we need a variable holding component? We're just casting entity pointer to entity type and component (or pool) is not used. Can we get rid of it then?

I made a lot of changes. The main goal was to make API functions fully correspond to open.mp's method names, types etc.

One method = one API function.
Function signature pattern is [return type] [ClassName]_[MethodName](parameters with the same type and order if possible)

Removed logic from all functions. They are just wrappers to delegate call to corresponding methods.
The logic can be written by users if needed.
For example, removed logic from [Player_SendDeathMessage](https://github.com/openmultiplayer/omp-capi/pull/3/commits/41395d9db13b3c65b728fdca3c10b358622e9690):
instead user can by themselves check if killee is null and either call Player_SendDeathMessage or Player_SendEmptyDeathMessage.
Another example is [Player_GetMarkerForPlayer](https://github.com/openmultiplayer/omp-capi/pull/3/commits/94b012010e6665092aea0ce9b89dca3fdf586a87). User will get boolean result and decide what to do next.

Moved all player data related functions to players APIs file. For example, Object_BeginEditing is now Player_BeginEditingObject.
This function doesn't accept an object parameter why name it with `Object_` prefix.
Maybe even better to create new group of functions `PlayerObjectData_*`.

Functions without actual return value now have `void` return type instead of `bool`.
Reason: it's just unnecessary to return boolean.
You may argue that this boolean could be useful for error indication.
If so, how do we indicate error in functions that actually return something? Add another `bool* error` parameter?
But that would break consistency. Either all functions need to have this parameter or none (I choosed none for now).

I stopped making changes for now, because I'm afraid you'll decline my suggestions and I'll just waste my time.
If you agree with me I will continue to change the rest of the functions.

### Added
- TextLabel_SetPosition function.
- TextLabel_SetText function.
- TextLabel_SetColor function.
- TextLabel_DetachFromPlayer function.
- TextLabel_DetachFromVehicle function.
- PlayerTextLabel_SetText function.
- PlayerTextLabel_SetColor function.
- PlayerTextLabel_AttachToPlayer function.
- PlayerTextLabel_DetachFromPlayer function.
- PlayerTextLabel_AttachToVehicle function.
- PlayerTextLabel_DetachFromVehicle function.
- PlayerTextLabel_SetPosition function.
- PlayerTextLabel_SetVirtualWorld function.
- Player_GetClientVersion function.
- Player_GetAimData function.
- Player_GetCameraLookAt function.
- Player_GetShopName function.

### Fixed
- fixed header generation script: function names with multiple underscores were truncated (for example, Core_GameMode_SetText in the header file were as Core_GameMode).
- fixed PlayerTextLabel_GetColor signature: should return directly but not via pointer parameter.
- removed unused `bool* valid` parameter in PlayerTextLabel_IsValid function.