### PR TITLE
event callback fixes

### DIFF
--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -397,7 +397,7 @@
       ]
     },
     {
-      "name": "onPlayerEditPlayerObject",
+      "name": "onPlayerObjectEdited",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -1043,20 +1043,52 @@
           "type": "void*"
         },
         {
+          "name": "originX",
+          "type": "float"
+        },
+        {
+          "name": "originY",
+          "type": "float"
+        },
+        {
+          "name": "originZ",
+          "type": "float"
+        },
+        {
+          "name": "hitPosX",
+          "type": "float"
+        },
+        {
+          "name": "hitPosY",
+          "type": "float"
+        },
+        {
+          "name": "hitPosZ",
+          "type": "float"
+        },
+        {
+          "name": "offsetX",
+          "type": "float"
+        },
+        {
+          "name": "offsetY",
+          "type": "float"
+        },
+        {
+          "name": "offsetZ",
+          "type": "float"
+        },
+        {
           "name": "weapon",
           "type": "int"
         },
         {
-          "name": "x",
-          "type": "float"
+          "name": "hitType",
+          "type": "int"
         },
         {
-          "name": "y",
-          "type": "float"
-        },
-        {
-          "name": "z",
-          "type": "float"
+          "name": "hitID",
+          "type": "int"
         }
       ]
     },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -501,7 +501,7 @@
       ]
     },
     {
-      "name": "onPlayerSelectObject",
+      "name": "onObjectSelected",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -531,7 +531,7 @@
       ]
     },
     {
-      "name": "onPlayerSelectPlayerObject",
+      "name": "onPlayerObjectSelected",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -233,6 +233,20 @@
       ]
     },
     {
+      "name": "onPlayerEnterPlayerGangZone",
+      "badret": "none",
+      "args": [
+        {
+          "name": "player",
+          "type": "void*"
+        },
+        {
+          "name": "zone",
+          "type": "void*"
+        }
+      ]
+    },
+    {
       "name": "onPlayerLeaveGangZone",
       "badret": "none",
       "args": [
@@ -247,7 +261,35 @@
       ]
     },
     {
+      "name": "onPlayerLeavePlayerGangZone",
+      "badret": "none",
+      "args": [
+        {
+          "name": "player",
+          "type": "void*"
+        },
+        {
+          "name": "zone",
+          "type": "void*"
+        }
+      ]
+    },
+    {
       "name": "onPlayerClickGangZone",
+      "badret": "none",
+      "args": [
+        {
+          "name": "player",
+          "type": "void*"
+        },
+        {
+          "name": "zone",
+          "type": "void*"
+        }
+      ]
+    },
+    {
+      "name": "onPlayerClickPlayerGangZone",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -447,12 +447,12 @@
           "type": "void*"
         },
         {
-          "name": "saved",
-          "type": "bool"
-        },
-        {
           "name": "index",
           "type": "int"
+        },
+        {
+          "name": "saved",
+          "type": "bool"
         },
         {
           "name": "model",

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -583,6 +583,20 @@
           "type": "void*"
         }
       ]
+    },
+    {
+      "name": "onPlayerPickUpPlayerPickup",
+      "badret": "none",
+      "args": [
+        {
+          "name": "player",
+          "type": "void*"
+        },
+        {
+          "name": "pickup",
+          "type": "void*"
+        }
+      ]
     }
   ],
   "TextDraw": [

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -857,20 +857,52 @@
           "type": "void*"
         },
         {
+          "name": "originX",
+          "type": "float"
+        },
+        {
+          "name": "originY",
+          "type": "float"
+        },
+        {
+          "name": "originZ",
+          "type": "float"
+        },
+        {
+          "name": "hitPosX",
+          "type": "float"
+        },
+        {
+          "name": "hitPosY",
+          "type": "float"
+        },
+        {
+          "name": "hitPosZ",
+          "type": "float"
+        },
+        {
+          "name": "offsetX",
+          "type": "float"
+        },
+        {
+          "name": "offsetY",
+          "type": "float"
+        },
+        {
+          "name": "offsetZ",
+          "type": "float"
+        },
+        {
           "name": "weapon",
           "type": "int"
         },
         {
-          "name": "x",
-          "type": "float"
+          "name": "hitType",
+          "type": "int"
         },
         {
-          "name": "y",
-          "type": "float"
-        },
-        {
-          "name": "z",
-          "type": "float"
+          "name": "hitID",
+          "type": "int"
         }
       ]
     },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -155,6 +155,10 @@
         {
           "name": "elapsed",
           "type": "int"
+        },
+        {
+          "name": "now",
+          "type": "long long"
         }
       ]
     }

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -154,7 +154,7 @@
       "args": [
         {
           "name": "elapsed",
-          "type": "int"
+          "type": "long long"
         },
         {
           "name": "now",

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -133,6 +133,10 @@
       "badret": "true",
       "args": [
         {
+          "name": "player",
+          "type": "void*"
+        },
+        {
           "name": "address",
           "type": "CAPIStringView"
         },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -981,20 +981,52 @@
           "type": "void*"
         },
         {
+          "name": "originX",
+          "type": "float"
+        },
+        {
+          "name": "originY",
+          "type": "float"
+        },
+        {
+          "name": "originZ",
+          "type": "float"
+        },
+        {
+          "name": "hitPosX",
+          "type": "float"
+        },
+        {
+          "name": "hitPosY",
+          "type": "float"
+        },
+        {
+          "name": "hitPosZ",
+          "type": "float"
+        },
+        {
+          "name": "offsetX",
+          "type": "float"
+        },
+        {
+          "name": "offsetY",
+          "type": "float"
+        },
+        {
+          "name": "offsetZ",
+          "type": "float"
+        },
+        {
           "name": "weapon",
           "type": "int"
         },
         {
-          "name": "x",
-          "type": "float"
+          "name": "hitType",
+          "type": "int"
         },
         {
-          "name": "y",
-          "type": "float"
-        },
-        {
-          "name": "z",
-          "type": "float"
+          "name": "hitID",
+          "type": "int"
         }
       ]
     },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -1432,7 +1432,7 @@
         },
         {
           "name": "enterexit",
-          "type": "int"
+          "type": "bool"
         },
         {
           "name": "interiorId",

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -1177,6 +1177,20 @@
       ]
     },
     {
+      "name": "onPlayerNameChange",
+      "badret": "none",
+      "args": [
+        {
+          "name": "player",
+          "type": "void*"
+        },
+        {
+          "name": "oldName",
+          "type": "CAPIStringView"
+        }
+      ]
+    },
+    {
       "name": "onPlayerInteriorChange",
       "badret": "none",
       "args": [

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -795,20 +795,52 @@
           "type": "void*"
         },
         {
+          "name": "originX",
+          "type": "float"
+        },
+        {
+          "name": "originY",
+          "type": "float"
+        },
+        {
+          "name": "originZ",
+          "type": "float"
+        },
+        {
+          "name": "hitPosX",
+          "type": "float"
+        },
+        {
+          "name": "hitPosY",
+          "type": "float"
+        },
+        {
+          "name": "hitPosZ",
+          "type": "float"
+        },
+        {
+          "name": "offsetX",
+          "type": "float"
+        },
+        {
+          "name": "offsetY",
+          "type": "float"
+        },
+        {
+          "name": "offsetZ",
+          "type": "float"
+        },
+        {
           "name": "weapon",
           "type": "int"
         },
         {
-          "name": "x",
-          "type": "float"
+          "name": "hitType",
+          "type": "int"
         },
         {
-          "name": "y",
-          "type": "float"
-        },
-        {
-          "name": "z",
-          "type": "float"
+          "name": "hitID",
+          "type": "int"
         }
       ]
     },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -167,10 +167,6 @@
         {
           "name": "player",
           "type": "void*"
-        },
-        {
-          "name": "vw",
-          "type": "int"
         }
       ]
     },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -355,7 +355,7 @@
       ]
     },
     {
-      "name": "onPlayerEditObject",
+      "name": "onObjectEdited",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -1267,6 +1267,10 @@
         {
           "name": "player",
           "type": "void*"
+        },
+        {
+          "name": "now",
+          "type": "long long"
         }
       ]
     }

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -1297,7 +1297,7 @@
           "type": "int"
         },
         {
-          "name": "result",
+          "name": "results",
           "type": "int"
         }
       ]

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -919,20 +919,52 @@
           "type": "void*"
         },
         {
+          "name": "originX",
+          "type": "float"
+        },
+        {
+          "name": "originY",
+          "type": "float"
+        },
+        {
+          "name": "originZ",
+          "type": "float"
+        },
+        {
+          "name": "hitPosX",
+          "type": "float"
+        },
+        {
+          "name": "hitPosY",
+          "type": "float"
+        },
+        {
+          "name": "hitPosZ",
+          "type": "float"
+        },
+        {
+          "name": "offsetX",
+          "type": "float"
+        },
+        {
+          "name": "offsetY",
+          "type": "float"
+        },
+        {
+          "name": "offsetZ",
+          "type": "float"
+        },
+        {
           "name": "weapon",
           "type": "int"
         },
         {
-          "name": "x",
-          "type": "float"
+          "name": "hitType",
+          "type": "int"
         },
         {
-          "name": "y",
-          "type": "float"
-        },
-        {
-          "name": "z",
-          "type": "float"
+          "name": "hitID",
+          "type": "int"
         }
       ]
     },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -341,7 +341,7 @@
       ]
     },
     {
-      "name": "onPlayerObjectMove",
+      "name": "onPlayerObjectMoved",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -735,6 +735,16 @@
       ]
     },
     {
+      "name": "onPlayerClientInit",
+      "badret": "none",
+      "args": [
+        {
+          "name": "player",
+          "type": "void*"
+        }
+      ]
+    },
+    {
       "name": "onPlayerRequestSpawn",
       "badret": "false",
       "args": [

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -331,7 +331,7 @@
   ],
   "Object": [
     {
-      "name": "onObjectMove",
+      "name": "onObjectMoved",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -1163,6 +1163,20 @@
       ]
     },
     {
+      "name": "onPlayerScoreChange",
+      "badret": "none",
+      "args": [
+        {
+          "name": "player",
+          "type": "void*"
+        },
+        {
+          "name": "score",
+          "type": "int"
+        }
+      ]
+    },
+    {
       "name": "onPlayerInteriorChange",
       "badret": "none",
       "args": [

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -497,6 +497,14 @@
         {
           "name": "scaleZ",
           "type": "float"
+        },
+        {
+          "name": "color1",
+          "type": "int"
+        },
+        {
+          "name": "color2",
+          "type": "int"
         }
       ]
     },

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -439,7 +439,7 @@
       ]
     },
     {
-      "name": "onPlayerEditAttachedObject",
+      "name": "onPlayerAttachedObjectEdited",
       "badret": "none",
       "args": [
         {

--- a/apidocs/events.json
+++ b/apidocs/events.json
@@ -137,10 +137,6 @@
           "type": "void*"
         },
         {
-          "name": "address",
-          "type": "CAPIStringView"
-        },
-        {
           "name": "password",
           "type": "CAPIStringView"
         },

--- a/src/Impl/Console/Events.hpp
+++ b/src/Impl/Console/Events.hpp
@@ -20,11 +20,6 @@ struct ConsoleEvents : public ConsoleEventHandler, public Singleton<ConsoleEvent
 
 	void onRconLoginAttempt(IPlayer& player, StringView password, bool success) override
 	{
-		PeerNetworkData data = player.getNetworkData();
-		PeerAddress::AddressString addressString;
-		PeerAddress::ToString(data.networkID.address, addressString);
-		StringView addressStringView = StringView(addressString.data(), addressString.length());
-
-		ComponentManager::Get()->CallEvent("onRconLoginAttempt", EventReturnHandler::StopAtTrue, &player, CREATE_CAPI_STRING_VIEW(addressStringView), CREATE_CAPI_STRING_VIEW(password), success);
+		ComponentManager::Get()->CallEvent("onRconLoginAttempt", EventReturnHandler::StopAtTrue, &player, CREATE_CAPI_STRING_VIEW(password), success);
 	}
 };

--- a/src/Impl/Console/Events.hpp
+++ b/src/Impl/Console/Events.hpp
@@ -25,6 +25,6 @@ struct ConsoleEvents : public ConsoleEventHandler, public Singleton<ConsoleEvent
 		PeerAddress::ToString(data.networkID.address, addressString);
 		StringView addressStringView = StringView(addressString.data(), addressString.length());
 
-		ComponentManager::Get()->CallEvent("onRconLoginAttempt", EventReturnHandler::StopAtTrue, CREATE_CAPI_STRING_VIEW(addressStringView), CREATE_CAPI_STRING_VIEW(password), success);
+		ComponentManager::Get()->CallEvent("onRconLoginAttempt", EventReturnHandler::StopAtTrue, &player, CREATE_CAPI_STRING_VIEW(addressStringView), CREATE_CAPI_STRING_VIEW(password), success);
 	}
 };

--- a/src/Impl/Core/Events.hpp
+++ b/src/Impl/Core/Events.hpp
@@ -15,6 +15,8 @@ struct CoreEvents : public CoreEventHandler, public Singleton<CoreEvents>
 {
 	void onTick(Microseconds elapsed, TimePoint now) override
 	{
-		ComponentManager::Get()->CallEvent("onTick", EventReturnHandler::None, int(elapsed.count()));
+		long long nowSeconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+
+		ComponentManager::Get()->CallEvent("onTick", EventReturnHandler::None, int(elapsed.count()), nowSeconds);
 	}
 };

--- a/src/Impl/Core/Events.hpp
+++ b/src/Impl/Core/Events.hpp
@@ -17,6 +17,6 @@ struct CoreEvents : public CoreEventHandler, public Singleton<CoreEvents>
 	{
 		long long nowSeconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
 
-		ComponentManager::Get()->CallEvent("onTick", EventReturnHandler::None, int(elapsed.count()), nowSeconds);
+		ComponentManager::Get()->CallEvent("onTick", EventReturnHandler::None, elapsed.count(), nowSeconds);
 	}
 };

--- a/src/Impl/CustomModels/Events.hpp
+++ b/src/Impl/CustomModels/Events.hpp
@@ -15,7 +15,7 @@ struct CustomModelsEvents : public PlayerModelsEventHandler, public Singleton<Cu
 {
 	virtual void onPlayerFinishedDownloading(IPlayer& player) override
 	{
-		ComponentManager::Get()->CallEvent("onPlayerFinishedDownloading", EventReturnHandler::None, &player, player.getVirtualWorld());
+		ComponentManager::Get()->CallEvent("onPlayerFinishedDownloading", EventReturnHandler::None, &player);
 	}
 
 	virtual bool onPlayerRequestDownload(IPlayer& player, ModelDownloadType type, uint32_t checksum) override

--- a/src/Impl/GangZones/Events.hpp
+++ b/src/Impl/GangZones/Events.hpp
@@ -21,6 +21,7 @@ struct GangZoneEvents : public GangZoneEventHandler, public Singleton<GangZoneEv
 		}
 		else if (auto data = queryExtension<IPlayerGangZoneData>(player))
 		{
+			ComponentManager::Get()->CallEvent("onPlayerEnterPlayerGangZone", EventReturnHandler::None, &player, &zone);
 		}
 	}
 
@@ -32,6 +33,7 @@ struct GangZoneEvents : public GangZoneEventHandler, public Singleton<GangZoneEv
 		}
 		else if (auto data = queryExtension<IPlayerGangZoneData>(player))
 		{
+			ComponentManager::Get()->CallEvent("onPlayerLeavePlayerGangZone", EventReturnHandler::None, &player, &zone);
 		}
 	}
 
@@ -43,6 +45,7 @@ struct GangZoneEvents : public GangZoneEventHandler, public Singleton<GangZoneEv
 		}
 		else if (auto data = queryExtension<IPlayerGangZoneData>(player))
 		{
+			ComponentManager::Get()->CallEvent("onPlayerClickPlayerGangZone", EventReturnHandler::None, &player, &zone);
 		}
 	}
 };

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -25,7 +25,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 
 	void onObjectEdited(IPlayer& player, IObject& object, ObjectEditResponse response, Vector3 offset, Vector3 rotation) override
 	{
-		ComponentManager::Get()->CallEvent("onPlayerEditObject", EventReturnHandler::None, &player, &object, int(response), offset.x, offset.y, offset.z, rotation.x, rotation.y, rotation.z);
+		ComponentManager::Get()->CallEvent("onObjectEdited", EventReturnHandler::None, &player, &object, int(response), offset.x, offset.y, offset.z, rotation.x, rotation.y, rotation.z);
 	}
 
 	void onPlayerObjectEdited(IPlayer& player, IPlayerObject& object, ObjectEditResponse response, Vector3 offset, Vector3 rotation) override

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -39,7 +39,8 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 			&player, index, saved, data.model, data.bone,
 			data.offset.x, data.offset.y, data.offset.z,
 			data.rotation.x, data.rotation.y, data.rotation.z,
-			data.scale.x, data.scale.y, data.scale.z);
+			data.scale.x, data.scale.y, data.scale.z,
+			data.colour1.RGBA(), data.colour2.RGBA());
 	}
 
 	void onObjectSelected(IPlayer& player, IObject& object, int model, Vector3 position) override

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -15,7 +15,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 {
 	void onMoved(IObject& object) override
 	{
-		ComponentManager::Get()->CallEvent("onObjectMove", EventReturnHandler::None, &object);
+		ComponentManager::Get()->CallEvent("onObjectMoved", EventReturnHandler::None, &object);
 	}
 
 	void onPlayerObjectMoved(IPlayer& player, IPlayerObject& object) override

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -30,7 +30,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 
 	void onPlayerObjectEdited(IPlayer& player, IPlayerObject& object, ObjectEditResponse response, Vector3 offset, Vector3 rotation) override
 	{
-		ComponentManager::Get()->CallEvent("onPlayerEditPlayerObject", EventReturnHandler::None, &player, &object, int(response), offset.x, offset.y, offset.z, rotation.x, rotation.y, rotation.z);
+		ComponentManager::Get()->CallEvent("onPlayerObjectEdited", EventReturnHandler::None, &player, &object, int(response), offset.x, offset.y, offset.z, rotation.x, rotation.y, rotation.z);
 	}
 
 	void onPlayerAttachedObjectEdited(IPlayer& player, int index, bool saved, const ObjectAttachmentSlotData& data) override

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -49,6 +49,6 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 
 	void onPlayerObjectSelected(IPlayer& player, IPlayerObject& object, int model, Vector3 position) override
 	{
-		ComponentManager::Get()->CallEvent("onPlayerSelectPlayerObject", EventReturnHandler::None, &player, &object, model, position.x, position.y, position.z);
+		ComponentManager::Get()->CallEvent("onPlayerObjectSelected", EventReturnHandler::None, &player, &object, model, position.x, position.y, position.z);
 	}
 };

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -36,7 +36,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 	void onPlayerAttachedObjectEdited(IPlayer& player, int index, bool saved, const ObjectAttachmentSlotData& data) override
 	{
 		ComponentManager::Get()->CallEvent("onPlayerAttachedObjectEdited", EventReturnHandler::None,
-			&player, saved, index, data.model, data.bone,
+			&player, index, saved, data.model, data.bone,
 			data.offset.x, data.offset.y, data.offset.z,
 			data.rotation.x, data.rotation.y, data.rotation.z,
 			data.scale.x, data.scale.y, data.scale.z);

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -40,7 +40,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 			data.offset.x, data.offset.y, data.offset.z,
 			data.rotation.x, data.rotation.y, data.rotation.z,
 			data.scale.x, data.scale.y, data.scale.z,
-			data.colour1.RGBA(), data.colour2.RGBA());
+			int(data.colour1.RGBA()), int(data.colour2.RGBA()));
 	}
 
 	void onObjectSelected(IPlayer& player, IObject& object, int model, Vector3 position) override

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -35,7 +35,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 
 	void onPlayerAttachedObjectEdited(IPlayer& player, int index, bool saved, const ObjectAttachmentSlotData& data) override
 	{
-		ComponentManager::Get()->CallEvent("onPlayerEditAttachedObject", EventReturnHandler::None,
+		ComponentManager::Get()->CallEvent("onPlayerAttachedObjectEdited", EventReturnHandler::None,
 			&player, saved, index, data.model, data.bone,
 			data.offset.x, data.offset.y, data.offset.z,
 			data.rotation.x, data.rotation.y, data.rotation.z,

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -20,7 +20,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 
 	void onPlayerObjectMoved(IPlayer& player, IPlayerObject& object) override
 	{
-		ComponentManager::Get()->CallEvent("onPlayerObjectMove", EventReturnHandler::None, &player, &object);
+		ComponentManager::Get()->CallEvent("onPlayerObjectMoved", EventReturnHandler::None, &player, &object);
 	}
 
 	void onObjectEdited(IPlayer& player, IObject& object, ObjectEditResponse response, Vector3 offset, Vector3 rotation) override

--- a/src/Impl/Objects/Events.hpp
+++ b/src/Impl/Objects/Events.hpp
@@ -44,7 +44,7 @@ struct ObjectEvents : public ObjectEventHandler, public Singleton<ObjectEvents>
 
 	void onObjectSelected(IPlayer& player, IObject& object, int model, Vector3 position) override
 	{
-		ComponentManager::Get()->CallEvent("onPlayerSelectObject", EventReturnHandler::None, &player, &object, model, position.x, position.y, position.z);
+		ComponentManager::Get()->CallEvent("onObjectSelected", EventReturnHandler::None, &player, &object, model, position.x, position.y, position.z);
 	}
 
 	void onPlayerObjectSelected(IPlayer& player, IPlayerObject& object, int model, Vector3 position) override

--- a/src/Impl/Pickups/Events.hpp
+++ b/src/Impl/Pickups/Events.hpp
@@ -21,6 +21,7 @@ struct PickupEvents : public PickupEventHandler, public Singleton<PickupEvents>
 		}
 		else if (auto data = queryExtension<IPlayerPickupData>(player))
 		{
+			ComponentManager::Get()->CallEvent("onPlayerPickUpPlayerPickup", EventReturnHandler::None, &player, &pickup);
 		}
 	}
 };

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -139,6 +139,11 @@ public:
 		ComponentManager::Get()->CallEvent("onPlayerScoreChange", EventReturnHandler::None, &player, score);
 	}
 
+	void onPlayerNameChange(IPlayer& player, StringView oldName) override
+	{
+		ComponentManager::Get()->CallEvent("onPlayerNameChange", EventReturnHandler::None, &player, CREATE_CAPI_STRING_VIEW(oldName));
+	}
+
 	void onPlayerInteriorChange(IPlayer& player, unsigned newInterior, unsigned oldInterior) override
 	{
 		ComponentManager::Get()->CallEvent("onPlayerInteriorChange", EventReturnHandler::None, &player, int(newInterior), int(oldInterior));

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -100,7 +100,12 @@ public:
 	bool onPlayerShotObject(IPlayer& player, IObject& target, const PlayerBulletData& bulletData) override
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotObject", EventReturnHandler::StopAtFalse, &player, &target,
-			int(bulletData.weapon), bulletData.offset.x, bulletData.offset.y, bulletData.offset.z);
+			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
+			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
+			int(bulletData.weapon),
+			int(bulletData.hitType),
+			int(bulletData.hitID));
 	}
 
 	bool onPlayerShotPlayerObject(IPlayer& player, IPlayerObject& target, const PlayerBulletData& bulletData) override

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -134,6 +134,11 @@ public:
 		ComponentManager::Get()->CallEvent("onPlayerGiveDamage", EventReturnHandler::None, &player, &to, amount, int(weapon), int(part));
 	}
 
+	void onPlayerScoreChange(IPlayer& player, int score) override
+	{
+		ComponentManager::Get()->CallEvent("onPlayerScoreChange", EventReturnHandler::None, &player, score);
+	}
+
 	void onPlayerInteriorChange(IPlayer& player, unsigned newInterior, unsigned oldInterior) override
 	{
 		ComponentManager::Get()->CallEvent("onPlayerInteriorChange", EventReturnHandler::None, &player, int(newInterior), int(oldInterior));

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -44,6 +44,11 @@ public:
 		ComponentManager::Get()->CallEvent("onPlayerDisconnect", EventReturnHandler::None, &player, int(reason));
 	}
 
+	void onPlayerClientInit(IPlayer& player) override
+	{
+		ComponentManager::Get()->CallEvent("onPlayerClientInit", EventReturnHandler::None, &player);
+	}
+
 	bool onPlayerRequestSpawn(IPlayer& player) override
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerRequestSpawn", EventReturnHandler::StopAtFalse, &player);

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -161,6 +161,10 @@ public:
 
 	bool onPlayerUpdate(IPlayer& player, TimePoint now) override
 	{
-		return ComponentManager::Get()->CallEvent("onPlayerUpdate", EventReturnHandler::StopAtFalse, &player);
+		auto nowMs = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+		auto value = nowMs.time_since_epoch();
+		long long nowMillis = value.count();
+
+		return ComponentManager::Get()->CallEvent("onPlayerUpdate", EventReturnHandler::StopAtFalse, &player, nowMillis);
 	}
 };

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -111,7 +111,12 @@ public:
 	bool onPlayerShotPlayerObject(IPlayer& player, IPlayerObject& target, const PlayerBulletData& bulletData) override
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotPlayerObject", EventReturnHandler::StopAtFalse, &player, &target,
-			int(bulletData.weapon), bulletData.offset.x, bulletData.offset.y, bulletData.offset.z);
+			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
+			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
+			int(bulletData.weapon),
+			int(bulletData.hitType),
+			int(bulletData.hitID));
 	}
 
 	void onPlayerDeath(IPlayer& player, IPlayer* killer, int reason) override

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -67,7 +67,12 @@ public:
 	bool onPlayerShotMissed(IPlayer& player, const PlayerBulletData& bulletData) override
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotMissed", EventReturnHandler::StopAtFalse, &player,
-			int(bulletData.weapon), bulletData.offset.x, bulletData.offset.y, bulletData.offset.z);
+			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
+			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
+			int(bulletData.weapon),
+			int(bulletData.hitType),
+			int(bulletData.hitID));
 	}
 
 	bool onPlayerShotPlayer(IPlayer& player, IPlayer& target, const PlayerBulletData& bulletData) override

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -78,7 +78,12 @@ public:
 	bool onPlayerShotPlayer(IPlayer& player, IPlayer& target, const PlayerBulletData& bulletData) override
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotPlayer", EventReturnHandler::StopAtFalse, &player, &target,
-			int(bulletData.weapon), bulletData.offset.x, bulletData.offset.y, bulletData.offset.z);
+			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
+			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
+			int(bulletData.weapon),
+			int(bulletData.hitType),
+			int(bulletData.hitID));
 	}
 
 	bool onPlayerShotVehicle(IPlayer& player, IVehicle& target, const PlayerBulletData& bulletData) override

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -89,7 +89,12 @@ public:
 	bool onPlayerShotVehicle(IPlayer& player, IVehicle& target, const PlayerBulletData& bulletData) override
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotVehicle", EventReturnHandler::StopAtFalse, &player, &target,
-			int(bulletData.weapon), bulletData.offset.x, bulletData.offset.y, bulletData.offset.z);
+			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
+			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
+			int(bulletData.weapon),
+			int(bulletData.hitType),
+			int(bulletData.hitID));
 	}
 
 	bool onPlayerShotObject(IPlayer& player, IObject& target, const PlayerBulletData& bulletData) override

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -73,7 +73,7 @@ public:
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotMissed", EventReturnHandler::StopAtFalse, &player,
 			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
-			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.hitPos.x, bulletData.hitPos.y, bulletData.hitPos.z,
 			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
 			int(bulletData.weapon),
 			int(bulletData.hitType),
@@ -84,7 +84,7 @@ public:
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotPlayer", EventReturnHandler::StopAtFalse, &player, &target,
 			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
-			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.hitPos.x, bulletData.hitPos.y, bulletData.hitPos.z,
 			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
 			int(bulletData.weapon),
 			int(bulletData.hitType),
@@ -95,7 +95,7 @@ public:
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotVehicle", EventReturnHandler::StopAtFalse, &player, &target,
 			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
-			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.hitPos.x, bulletData.hitPos.y, bulletData.hitPos.z,
 			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
 			int(bulletData.weapon),
 			int(bulletData.hitType),
@@ -106,7 +106,7 @@ public:
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotObject", EventReturnHandler::StopAtFalse, &player, &target,
 			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
-			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.hitPos.x, bulletData.hitPos.y, bulletData.hitPos.z,
 			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
 			int(bulletData.weapon),
 			int(bulletData.hitType),
@@ -117,7 +117,7 @@ public:
 	{
 		return ComponentManager::Get()->CallEvent("onPlayerShotPlayerObject", EventReturnHandler::StopAtFalse, &player, &target,
 			bulletData.origin.x, bulletData.origin.y, bulletData.origin.z,
-			bulletData.hitpos.x, bulletData.hitPos.y, bulletData.hitPos.z,
+			bulletData.hitPos.x, bulletData.hitPos.y, bulletData.hitPos.z,
 			bulletData.offset.x, bulletData.offset.y, bulletData.offset.z,
 			int(bulletData.weapon),
 			int(bulletData.hitType),

--- a/src/Impl/Players/Events.hpp
+++ b/src/Impl/Players/Events.hpp
@@ -176,10 +176,8 @@ public:
 
 	bool onPlayerUpdate(IPlayer& player, TimePoint now) override
 	{
-		auto nowMs = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
-		auto value = nowMs.time_since_epoch();
-		long long nowMillis = value.count();
+		long long nowSeconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
 
-		return ComponentManager::Get()->CallEvent("onPlayerUpdate", EventReturnHandler::StopAtFalse, &player, nowMillis);
+		return ComponentManager::Get()->CallEvent("onPlayerUpdate", EventReturnHandler::StopAtFalse, &player, nowSeconds);
 	}
 };

--- a/tools/generate_single_header.js
+++ b/tools/generate_single_header.js
@@ -271,7 +271,7 @@ ${event.args.map((param) => `        ${convertEventArgTypeNames(param.type)}* ${
 };
 typedef bool (*EventCallback_${event.name})(struct EventArgs_${
           event.name
-        } args);\n`
+        }* args);\n`
       );
     });
   });

--- a/tools/generate_single_header.js
+++ b/tools/generate_single_header.js
@@ -126,7 +126,7 @@ const convertFunctionArgTypeNames = (type) => {
 
 const convertEventArgTypeNames = (type) => {
   if (type === "CAPIStringView") {
-    return "struct CAPIStringView*";
+    return "struct CAPIStringView";
   } else {
     return type;
   }


### PR DESCRIPTION
### Proposals
- Change CAPIStringView `len` type to `size_t` instead of `unsigned len` and `data` type to `const char*` instead of `char*`.
- Introduce something like `CAPIArray` to be able to implement functions like `Vehicle_GetPassengers`, `All_GetPlayers`, `Player_GetWeapons` and so on (and a function for freeing it?).

### Added
- onPlayerScoreChange callback.
- onPlayerNameChange callback.
- onPlayerClientInit callback.
- color1 and color2 in onPlayerAttachedObjectEdited callback parameter list.
- more parameters to onPlayerShotMissed callback.
- more parameters to onPlayerShotPlayer callback.
- more parameters to onPlayerShotVehicle callback.
- more parameters to onPlayerShotObject callback.
- more parameters to onPlayerShotPlayerObject callback.
- _now_ parameter to onPlayerUpdate callback parameter list.
- _now_ parameter to onTick callback parameter list.

Also added per player pickup and gangzone callbacks, because why not if we have per player textdraw and object callbacks:
- onPlayerPickUpPlayerPickup callback.
- onPlayerEnterPlayerGangZone callback.
- onPlayerLeavePlayerGangZone callback.
- onPlayerClickPlayerGangZone callback.


### Changed
Most of these changes are made to reflect open.mp components methods signature. There is no need to maintain Pawn-like API.
- onRconLoginAttempt callback now have player, password and success parameters corresponding to onRconLoginAttempt method in ConsoleEvents class. Removed address parameter.
- removed vw parameter in onPlayerFinishedDownloading callback. We can get it by using Player_GetVirtualWorld.
- renamed onObjectMove -> onObjectMoved.
- renamed onPlayerObjectMove -> onPlayerObjectMoved.
- renamed onPlayerEditObject -> onObjectEdited.
- renamed onPlayerEditPlayerObject -> onPlayerObjectEdited.
- renamed onPlayerEditAttachedObject -> onPlayerAttachedObjectEdited.
- renamed onPlayerSelectObject -> onObjectSelected.
- renamed onPlayerSelectPlayerObject -> onPlayerObjectSelected.
- changed onPlayerAttachedObjectEdited callback parameters order (first index, then saved).
- renamed onClientCheckResponse parameter result -> results.

### Fixed
- onEnterExitModShop enterexit parameter type has to be bool not int.
- Callback types parameter type has to be pointer to struct not struct.
- remove type casting elapsed _parameter_ from long long to int in onTick callback
- CAPIStringView type in EventArgs_* structs were generated as `struct CAPIStringView**`, fixed it to be `struct CAPIStringView*`