### PR TITLE
dialogs and checkpoint component members are initialized

### DIFF
--- a/src/Impl/ComponentManager.cpp
+++ b/src/Impl/ComponentManager.cpp
@@ -87,6 +87,8 @@ void ComponentManager::Init(ICore* c, IComponentList* clist)
 	menus = GetComponent<IMenusComponent>();
 	textdraws = GetComponent<ITextDrawsComponent>();
 	gangzones = GetComponent<IGangZonesComponent>();
+	checkpoints = GetComponent<ICheckpointsComponent>();
+	dialogs = GetComponent<IDialogsComponent>();
 }
 
 void ComponentManager::InitializeEvents()


### PR DESCRIPTION
`dialogs` and `checkpoints` members were not initialized on constructor, causing the corresponding callbacks of these components not getting registered. This PR fixes that. 