### PR TITLE
Fix event call flow 

### DIFF
--- a/src/Impl/ComponentManager.hpp
+++ b/src/Impl/ComponentManager.hpp
@@ -97,7 +97,7 @@ public:
 		auto low_ = fairlyLowPriorityEvents.find(name);
 		auto lowest_ = lowestPriorityEvents.find(name);
 
-		bool result = true;
+		bool result = returnHandler != EventReturnHandler::StopAtTrue;
 
 		if (highest_ != highestPriorityEvents.end())
 		{
@@ -198,11 +198,8 @@ private:
 						return true;
 					}
 					break;
-				case EventReturnHandler::None:
-				default:
-					result = ret;
-					break;
 				}
+				result = ret;
 			}
 		}
 


### PR DESCRIPTION
properly set default value for `result` for events that stop at a true value and always store the return value of last in the chain if no early stop used